### PR TITLE
Fix overlay text showing on newly obtained abilities

### DIFF
--- a/talent-calculator.js
+++ b/talent-calculator.js
@@ -149,10 +149,6 @@ class TalentCalculator extends HTMLElement {
   #showLevelOrderOverlay(show) {
     const abilities = this.querySelectorAll('ability-pick');
     abilities.forEach(ability => {
-      // Ignore unobtained or innate abilities.
-      if (!ability.obtained || ability.innate) {
-        return;
-      }
       if (show) {
         ability.showOverlayText();
       } else {


### PR DESCRIPTION
Turning off the overlay text and then clicking on a new ability, 
shows the overlay text on the new ability. 

The code that hides the overlay text 
(which previously ignored unobtained abilities)
now is applied on all abilities
which fixes the problem.