### PR TITLE
Athletics tree tooltips

### DIFF
--- a/components/ability-pick/ability-pick.css
+++ b/components/ability-pick/ability-pick.css
@@ -62,6 +62,11 @@
     left: 120%;
 }
 
+.tooltip-top-right {
+    bottom: -120%;
+    left: 120%;
+}
+
 .tooltip-top {
     bottom: 120%;
     left: -220%;

--- a/components/ability-pick/ability-pick.js
+++ b/components/ability-pick/ability-pick.js
@@ -274,6 +274,9 @@ class AbilityPick extends HTMLElement {
     if (this.hasAttribute('tooltip-top')) {
       tooltip.classList.add('tooltip-top');
     }
+    if (this.hasAttribute('tooltip-top-right')) {
+      tooltip.classList.add('tooltip-top-right');
+    }
     if (this.hasAttribute('tooltip-bottom')) {
       tooltip.classList.add('tooltip-bottom');
     }

--- a/components/ability-pick/ability-pick.js
+++ b/components/ability-pick/ability-pick.js
@@ -243,7 +243,7 @@ class AbilityPick extends HTMLElement {
     }  
     // Position tooltip to the left of the ability pick,
     // if it exceeds the right of the window.
-    if (x2 > window.innerWidth) {
+    if (x2 > window.outerWidth) {
       this.#tooltip.style.left = 'auto';
       this.#tooltip.style.right = distance;
     }
@@ -255,7 +255,7 @@ class AbilityPick extends HTMLElement {
     }
     // Position tooltip to the top of the ability pick,
     // if it exceeds the bottom of the window.
-    if (y2 > window.innerHeight) {
+    if (y2 > window.outerHeight) {
       this.#tooltip.style.top = 'auto';
       this.#tooltip.style.bottom = distance;
     }

--- a/components/ability-pick/ability-pick.js
+++ b/components/ability-pick/ability-pick.js
@@ -353,19 +353,24 @@ class AbilityPick extends HTMLElement {
       rangeTemplate = makeAbilityStatTemplate('Range', this.#range);
     }
 
+    let addLine = false;
+
     let backfireChanceTemplate = '';
     if (this.#backfireChance) {
       backfireChanceTemplate = makeAbilityStatTemplate('Backfire Chance', this.#backfireChance);
+      addLine = true;
     }
 
     let modifiedByTemplate = '';
     if (this.#modifiedBy.length > 0) {
       modifiedByTemplate = `<p><span class="modified-by">Modified by:</span> ${this.#modifiedBy.join(', ')}</p>`;
+      addLine = true;
     }
 
     let requiresTemplate = '';
     if (this.#requires) {
       requiresTemplate = `<p><span class="requires">- ${this.#requires}</span></p>`;
+      addLine = true;
     }
     
     tooltip.innerHTML = `
@@ -376,7 +381,7 @@ class AbilityPick extends HTMLElement {
         ${backfireChanceTemplate}
         ${modifiedByTemplate}
         ${requiresTemplate}
-        ${this.#requires ? '<hr>' : ''}
+        ${addLine ? '<hr>' : ''}
         <slot name="description"></slot>
       </section>
     `

--- a/components/stat-formula/character.js
+++ b/components/stat-formula/character.js
@@ -15,5 +15,6 @@ export default class Character {
     this.perception = 10;
     this.vitality = 10;
     this.willpower = 10;
+    this.legsDef = 0;
   }
 }

--- a/components/stat-formula/stat-formula.js
+++ b/components/stat-formula/stat-formula.js
@@ -17,13 +17,11 @@ class StatFormula extends HTMLElement {
 
   connectedCallback () {
     this.#formula = this.innerHTML;
-    console.log();
     this.#eval = this.#replaceStats(this.#formula);
     this.#result = eval?.(`"use strict";(${this.#eval})`);
     if (this.hasAttribute('plus')) {
       this.#result = (this.#result <= 0 ? '' : '+') + this.#result; // Add plus sign in case of positive result.
     }
-    console.log(`${this.#formula} = ${this.#result}`);
     this.innerHTML = this.#result;
   }
 
@@ -33,6 +31,8 @@ class StatFormula extends HTMLElement {
     formula = formula.replaceAll('PRC', this.#character.perception);
     formula = formula.replaceAll('VIT', this.#character.vitality);
     formula = formula.replaceAll('WIL', this.#character.willpower);
+    formula = formula.replaceAll('Legs_DEF', this.#character.legsDef)
+    
     return formula;
   }
 

--- a/index.html
+++ b/index.html
@@ -236,7 +236,6 @@
             <ability-pick id="swords-8"                              parents="swords-5 swords-6"
                 style="top: 377px; left: 187px;" img="img/abilities/swords/Onrush.png"
                 title="Onrush"
-                title="Fencer's Stance"
                 primary-type="Attack"
                 secondary-type="Charge"
                 energy="20"

--- a/index.html
+++ b/index.html
@@ -412,19 +412,239 @@
             <ability-pick id="warfare-14"                                  parents="warfare-11"          style="top: 421px; left: 213px;" img="img/abilities/warfare/Final_Push.png" title="Final Push"></ability-pick>
         </ability-tree>
         <ability-tree id="athletics" title="Athletics">
-            <ability-pick id="athletics-1"  children="athletics-5"                                                               style="top: 85px; left: 23px;"   img="img/abilities/athletics/Disengage.png" title="Disengage"></ability-pick>
-            <ability-pick id="athletics-2"  children="athletics-6"                                                               style="top: 85px; left: 99px;"   img="img/abilities/athletics/Leg_Sweep.png" title="Leg Sweep"></ability-pick>
-            <ability-pick id="athletics-3"  children="athletics-7"                                                               style="top: 85px; left: 175px;"  img="img/abilities/athletics/Not_This_Time.png" title="Not This Time"></ability-pick>
-            <ability-pick id="athletics-4"  children="athletics-8"                                                               style="top: 85px; left: 251px;"  img="img/abilities/athletics/Mighty_Kick.png" title="Mighty Kick"></ability-pick>
-            <ability-pick id="athletics-5"  children="athletics-9"                            parents="athletics-1"              style="top: 197px; left: 23px;"  img="img/abilities/athletics/Dash.png" title="Dash"></ability-pick>
-            <ability-pick id="athletics-6"  children="athletics-9"                            parents="athletics-2"              style="top: 197px; left: 99px;"  img="img/abilities/athletics/Inner_Reserves.png" title="Inner Reserves"></ability-pick>
-            <ability-pick id="athletics-7"  children="athletics-10"                           parents="athletics-3"              style="top: 197px; left: 175px;" img="img/abilities/athletics/Sudden_Lunge.png" title="Sudden Lunge"></ability-pick>
-            <ability-pick id="athletics-8"  children="athletics-10"                           parents="athletics-4"              style="top: 197px; left: 251px;" img="img/abilities/athletics/Push_the_Falling.png" title="Push the Falling"></ability-pick>
-            <ability-pick id="athletics-9"  children="athletics-11 athletics-12 athletics-13" parents="athletics-5|athletics-6"  style="top: 309px; left: 100px;" img="img/abilities/athletics/Elusiveness.png" title="Elusiveness"></ability-pick>
-            <ability-pick id="athletics-10" children="athletics-11 athletics-12 athletics-13" parents="athletics-7|athletics-8"  style="top: 309px; left: 175px;" img="img/abilities/athletics/No_Time_to_Linger.png" title="No Time to Linger"></ability-pick>
-            <ability-pick id="athletics-11"                                                   parents="athletics-9 athletics-10" style="top: 421px; left: 61px;"  img="img/abilities/athletics/Sprint_Training.png" title="Sprint Training"></ability-pick>
-            <ability-pick id="athletics-12"                                                   parents="athletics-9 athletics-10" style="top: 421px; left: 137px;" img="img/abilities/athletics/Adrenaline_Rush.png" title="Adrenaline Rush"></ability-pick>
-            <ability-pick id="athletics-13"                                                   parents="athletics-9 athletics-10" style="top: 421px; left: 213px;" img="img/abilities/athletics/Peak_Performance.png" title="Peak Performance"></ability-pick>
+            <ability-pick id="athletics-1"  children="athletics-5"
+                style="top: 85px; left: 23px;" img="img/abilities/athletics/Disengage.png"
+                title="Disengage"
+                passive
+                tooltip-right>
+                <div slot="description" class="tooltip-description">
+                    <p>Reduces the chance of triggering attacks of opportunity (from <span class="debuff">50%</span> to <span class="debuff">25%</span>).</p>
+
+                    <p>Grants <span class="buff">+0.2%</span> Magic Resistance and <span class="buff">+0.2</span> Nature Resistance for each <span class="buff">1%</span> Dodge Chance</p>
+
+                    <p>Applies all adjacent enemies with <span class="debuff">+3%</span> Fumble Chance, <span class="debuff">-3%</span> Accuracy, and <span class="debuff">-3%</span> Crit Chance.</p>
+                </div>
+            </ability-pick>
+            <ability-pick id="athletics-2"  children="athletics-6"
+                style="top: 85px; left: 99px;" img="img/abilities/athletics/Leg_Sweep.png"
+                title="Leg Sweep"
+                primary-type="Maneuver"
+                energy="10"
+                cooldown="8"
+                target-type="Target Area"
+                range="1"
+                modified-by="Strength Agility Perception"
+                tooltip-right>
+                <div slot="description" class="tooltip-description">
+                    <p>Deals <strong><stat-formula>(4 + (0.4 * Legs_DEF)) + (0.3 * STR)</stat-formula> Crushing Damage</strong> to three adjacent tiles with <strong><stat-formula>(80 + (2 * PRC))</stat-formula>%</strong> Accuracy 
+                    and <strong><stat-formula>(65 + (2 * AGL))</stat-formula>%</strong> Immobilization Chance.<br>
+                    Then allows to <strong>Reposition</strong> to an adjacent tile.</p>
+
+                    <p>The damage dealt depends on the equipped <strong>boots'</strong> Protection.</p>
+
+                    <p>Hitting a target applies it with <span class="debuff"><stat-formula plus>(5 + (0.5 * AGL))</stat-formula>%</span> Fumble Chance, 
+                        <span class="debuff"><stat-formula>-(5 + (0.5 * PRC))</stat-formula>%</span> Crit Chance, 
+                        and <strong><stat-formula>-(5 + (0.5 * STR))</stat-formula>%</strong> Weapon Damage for <strong>3</strong> turns.</p>
+
+                    <p>The effect stacks up to <strong>2</strong> times.</p>
+
+                    <p>If the target was hit by the strike and is adjacent after using the skill, 
+                        with <strong><stat-formula>(105 + (2 * STR))</stat-formula>%</strong> chance applies it with <strong>Stagger</strong>.</p>
+                </div>
+            </ability-pick>
+            <ability-pick id="athletics-3"  children="athletics-7"
+                style="top: 85px; left: 175px;" img="img/abilities/athletics/Not_This_Time.png"
+                title="Not This Time"
+                passive
+                tooltip-bottom>
+                <div slot="description" class="tooltip-description">
+                    <p>Full blocks and dodges grant <span class="buff">+5%</span> Control Resistance 
+                        and <span class="buff">+5%</span> Move Resistance for <strong>5</strong> turns.</p>
+
+                    <p>The effect stacks up to <strong>2</strong> times.</p>
+
+                    <p>Once per <strong>90</strong> turns removes <strong>Stun</strong>, <strong>Daze</strong>, <strong>Stagger</strong> 
+                        or <strong>Immobilization</strong> upon receiving them.</p>
+                </div>
+            </ability-pick>
+            <ability-pick id="athletics-4"  children="athletics-8"
+                style="top: 85px; left: 251px;"  img="img/abilities/athletics/Mighty_Kick.png"
+                title="Mighty Kick"
+                primary-type="Maneuver"
+                energy="6"
+                cooldown="6"
+                target-type="Target Object"
+                range="1"
+                modified-by="Strength Agility Perception"
+                tooltip-left>
+                <div slot="description" class="tooltip-description">
+                    <p>Deals <strong><stat-formula>10 + (0.4 * Legs_DEF) + (0.25 * STR)</stat-formula> Crushing Damage</strong> 
+                        with <strong><stat-formula>(100 + (2 * PRC))</stat-formula>%</strong> Accuracy, 
+                        <strong><stat-formula>(80 + (2 * AGL))</stat-formula>%</strong> Stagger Chance 
+                        and <strong><stat-formula>(60 + (2 * STR))</stat-formula>%</strong> Knockback Chance.</p>
+
+                    <p>The damage dealt depends on the equipped <strong>boots'</strong> Protection.</p>
+
+                    <p>Hitting the target applies it with <span class="debuff"><stat-formula>(-3 * STR)</stat-formula>%</span> Max Block Power, 
+                        <span class="debuff"><stat-formula>-(AGL + PRC)</stat-formula>%</span> Control Resistance, 
+                        <span class="debuff"><stat-formula>-(AGL + PRC)</stat-formula>%</span> Move Resistance, 
+                        and <span class="debuff"><stat-formula>(-1.5 * PRC)</stat-formula>%</span> Crit Avoidance for <strong>4</strong> turns.</p>
+
+                    <p>The effect stacks up to <strong>2</strong> times.</p>
+                </div>
+            </ability-pick>
+            <ability-pick id="athletics-5"  children="athletics-9"                            parents="athletics-1"
+                style="top: 197px; left: 23px;" img="img/abilities/athletics/Dash.png" 
+                title="Dash"
+                primary-type="Charge"
+                energy="26"
+                cooldown="20"
+                target-type="Target Tile"
+                range="4"
+                tooltip-right>
+                <div slot="description" class="tooltip-description">
+                    <p>Performs a <strong>charge</strong> towards the targeted tile.</p>
+
+                    <p>Grants the skill <span class="debuff">-1</span> Range for each adjacent enemy (down to <strong>2</strong> range).</p>
+
+                    <p>If there are adjacent enemies after using the skill, grants <span class="buff">+15%</span> Dodge Chance 
+                        and <span class="buff">+15%</span> Counter Chance for <strong>2</strong> turns.</p>
+                </div>
+            </ability-pick>
+            <ability-pick id="athletics-6"  children="athletics-9"                            parents="athletics-2"
+                style="top: 197px; left: 99px;" img="img/abilities/athletics/Inner_Reserves.png"
+                title="Inner Reserves"
+                passive
+                tooltip-bottom>
+                <div slot="description" class="tooltip-description">
+                    <p>Once per <strong>30</strong> turns replenishes <span class="energy"><stat-formula>(5 + WIL)</stat-formula>%</span> Max Energy 
+                        when Energy drops below <span class="energy">33%</span>.</p>
+                </div>
+            </ability-pick>
+            <ability-pick id="athletics-7"  children="athletics-10"                           parents="athletics-3"
+                style="top: 197px; left: 175px;" img="img/abilities/athletics/Sudden_Lunge.png"
+                title="Sudden Lunge"
+                primary-type="Attack"
+                energy="14"
+                cooldown="12"
+                target-type="Target Object"
+                range="1"
+                modified-by="Agility Perception"
+                tooltip-left>
+                <div slot="description" class="tooltip-description">
+                    <p>Delivers a strike with <span class="debuff">-50%</span> Weapon Damage 
+                        and <strong><stat-formula>(40 + (2 * AGL) + (2 * PRC))</stat-formula>%</strong> Stagger Chance.</p>
+
+                    <p>Reduces all cooldowns by <span class="buff">2</span> turns.</p>
+
+                    <p>If the strike does damage, puts the target's abilities on a <strong>2</strong> turns Cooldown.</p>
+
+                    <p>If equipped with a <strong>spear</strong>, grants the skill <span class="buff">+1</span> range.</p>
+                </div>
+            </ability-pick>
+            <ability-pick id="athletics-8"  children="athletics-10"                           parents="athletics-4"
+                style="top: 197px; left: 251px;" img="img/abilities/athletics/Push_the_Falling.png"
+                title="Push the Falling"
+                passive
+                tooltip-left>
+                <div slot="description" class="tooltip-description">
+                    <p><strong>Dazing</strong>, <strong>Stunning</strong>, <strong>Staggering</strong>, <strong>Confusing</strong>, <strong>Immobilizing</strong>, 
+                        and causing <span class="debuff">Bleeding</span> with strikes replenishes <span class="energy"><stat-formula>(-6 + WIL)</stat-formula>%</span> Max Energy.</p>
+
+                    <p>Using <strong>"Mighty Kick"</strong> against targets with these effects 
+                        prolongs their duration by <span class="debuff">1-2</span> turns, 
+                        depending on each individual effect's duration cap.</p>
+                </div>
+            </ability-pick>
+            <ability-pick id="athletics-9"  children="athletics-11 athletics-12 athletics-13" parents="athletics-5|athletics-6"
+                style="top: 309px; left: 100px;" img="img/abilities/athletics/Elusiveness.png"
+                title="Elusiveness"
+                primary-type="Maneuver"
+                energy="16"
+                cooldown="24"
+                target-type="No Target"
+                modified-by="Agility Vitality Perception"
+                tooltip-top-right>
+                <div slot="description" class="tooltip-description">
+                    <p>Activates <strong>5</strong> stacks of <span class="buff">"Elusiveness"</span> for <strong>6</strong> turns:</p>
+
+                    <p><span class="buff" plus><stat-formula>(0.6 * PRC)</stat-formula>%</span> Dodge Chance<br>
+                    <span class="buff"><stat-formula>(-0.3 * VIT)</stat-formula>%</span> Damage Taken</p>
+
+                    <p>Each dodge as well as recieved fumbled strikes and shots 
+                        prelong the effect's duration by <span class="buff">1</span> turn 
+                        (up to <strong>6</strong>) but reduce its number of stacks.</p>
+
+                    <p>Moving to other tiles (<strong>Charges</strong> and <strong>Maneuvers</strong> count as well) 
+                        grants an extra stack of the effect for each traveled tile (up to <strong>V</strong>).</p>
+
+                    <p>Applies all adjacent enemies with <span class="debuff"><stat-formula plus>(AGL)</stat-formula>%</span> Fumble Chance for <strong>4</strong> turns.</p>
+
+                    <p>The effect doesn't stack.</p>
+                </div>
+            </ability-pick>
+            <ability-pick id="athletics-10" children="athletics-11 athletics-12 athletics-13" parents="athletics-7|athletics-8"
+                style="top: 309px; left: 175px;" img="img/abilities/athletics/No_Time_to_Linger.png"
+                title="No Time to Linger"
+                passive
+                tooltip-top>
+                <div slot="description" class="tooltip-description">
+                    <p>Grants strikes and shots against <strong>Dazed</strong>, <strong>Stunned</strong>, <strong>Staggered</strong>, 
+                        <strong>Confused</strong>, <strong>Immobilized</strong>, or <span class="debuff">Bleeding</span> targets 
+                        <span class="buff">+5%</span> Accuracy, <span class="buff">-5%</span> Fumble Chance, and <span class="buff">+5%</span> Crit Chance.</p>
+
+                    <p>Using <span class="buff">"Sudden Lunge"</span> against targets with these effects 
+                        grants the strike <span class="buff">+25%</span> Weapon Damage and doesn't take a turn.</p>
+                </div>
+            </ability-pick>
+            <ability-pick id="athletics-11"                                                   parents="athletics-9 athletics-10"
+                style="top: 421px; left: 61px;" img="img/abilities/athletics/Sprint_Training.png" 
+                title="Sprint Training"
+                passive
+                tooltip-top>
+                <div slot="description" class="tooltip-description">
+                    Grants <span class="buff">+1</span> Range, <span class="buff">-30%</span> Energy Cost, 
+                    and <span class="buff">-30%</span> Cooldown Duration to all <strong>Charge</strong> skills.
+                </div>
+            </ability-pick>
+            <ability-pick id="athletics-12"                                                   parents="athletics-9 athletics-10"
+                style="top: 421px; left: 137px;" img="img/abilities/athletics/Adrenaline_Rush.png"
+                title="Adrenaline Rush"
+                primary-type="Maneuver"
+                energy="20"
+                cooldown="60"
+                target-type="No Target"
+                modified-by="Vitality Willpower"
+                tooltip-top>
+                <div slot="description" class="tooltip-description">
+                    <p>Replenishes <span class="energy"><stat-formula>(WIL)</stat-formula>%</span> Max Energy, 
+                        grants <span class="buff"><stat-formula>(-2 * WIL)</stat-formula>%</span> Pain, 
+                        and activates <span class="buff">"Adrenaline Rush"</span> for <strong><stat-formula>(0.5 * VIT)</stat-formula></strong> turns:</p>
+
+                    <p><span class="buff">-5%</span> Damage Taken<br>
+                    <span class="buff">-10%</span> Skills Energy Cost<br>
+                    <span class="buff">+10%</span> Energy Restoration<br>
+                    <span class="buff">+5%</span> Crit Chance<br>
+                    <span class="buff">+10%</span> Pain Resistance<br>
+                    <strong>III</strong> stacks: reduces all Cooldowns by <span class="buff">1</span> turn.<br>
+                    <strong>VI</strong> stacks: replenishes <span class="buff">4%</span> Max Health if the current Health is below <span class="debuff">40%</span></p>
+                    
+                    <p>Grants and extra stack of the effect (up to <strong>VI</strong>) for each enemy within Vision upon activating it.<br>
+                    Adjacent enemies are counted twice.</p>
+                    
+                    <p>The effect's duration and the amount of reduced Pain and replenished Energy increase with missing Health.</p>
+                </div>
+            </ability-pick>
+            <ability-pick id="athletics-13"                                                   parents="athletics-9 athletics-10"
+                style="top: 421px; left: 213px;" img="img/abilities/athletics/Peak_Performance.png"
+                title="Peak Performance"
+                passive
+                tooltip-top>
+                <div slot="description" class="tooltip-description">
+                    <p>Grants <span class="buff">+10%</span> Weapon Damage, <span class="buff">+10%</span> Dodge Chance and <span class="buff">-10%</span> Cooldowns Duration 
+                        if Energy is above <span class="energy">50%</span>.</p>
+                </div>
+            </ability-pick>
         </ability-tree>
         <ability-tree id="magic_mastery" title="Magic Mastery">
             <ability-pick id="magic_mastery-1"  children="magic_mastery-5 magic_mastery-6"                                              style="top: 85px; left: 23px;"   img="img/abilities/magic_mastery/Seal_of_Finesse.png" title="Seal of Finesse"></ability-pick>


### PR DESCRIPTION
- Add athletics tree tooltips
- Detect Legs_DEF stat in formulas
- Adjust tooltip's position based on the window's outer width/height
- Add tooltip top-right position
- Fix missing hr when there's no "requires" in the tooltip-
- Remove double title

Closes #37