### PR TITLE
Fix Short Circuit ability children

### DIFF
--- a/index.html
+++ b/index.html
@@ -4294,7 +4294,7 @@
                     <p>The effect doesn't stack.</p>
                 </div>
             </ability-pick>
-            <ability-pick id="electromancy-4"  children="electromancy-8 electromancy-9"                                   parents="electromancy-1"
+            <ability-pick id="electromancy-4"  children="electromancy-7 electromancy-8"                                   parents="electromancy-1"
                 style="top: 197px; left: 99px;"
                 img="img/abilities/electromancy/Short_Circuit.png"
                 title="Short Circuit"


### PR DESCRIPTION
Short Circuit had wrong children which made it unable to be refunded if those children were selected first.

Fixes #74 