### PR TITLE
Hide level order overlay by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
                 </div>
             </div>
             <div class="checkbox">
-                <input type="checkbox" id="show-level-order-checkbox" checked>
+                <input type="checkbox" id="show-level-order-checkbox">
                 <label for="show-level-order-checkbox">Show Level Order</label>
             </div>
             <div class="checkbox">

--- a/talent-calculator.js
+++ b/talent-calculator.js
@@ -127,6 +127,8 @@ class TalentCalculator extends HTMLElement {
 
     this.#showLevelOrderCheckbox = this.querySelector('#show-level-order-checkbox');
     this.#showLevelOrderCheckbox.addEventListener('click', () => this.#showLevelOrderOverlay(this.#showLevelOrderCheckbox.checked));
+    // Hide level order overlay, if the checkbox is unchecked.
+    this.#showLevelOrderOverlay(this.#showLevelOrderCheckbox.checked);
 
     const showFormulasCheckbox = this.querySelector('#show-formulas-checkbox');
     showFormulasCheckbox.addEventListener('click', () => this.#showTooltipFormulas(showFormulasCheckbox.checked));


### PR DESCRIPTION
Now that level order is included in the build code (#97), it makes more sense for the default sharing behavior to exclude it, particularly since level order is currently unrestricted and requires extra effort to record accurately (e.g., keeping the game open while planning).