### PR TITLE
Update Arcanistics skill descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -4861,13 +4861,12 @@
                 passive
                 tooltip-top-left>
                 <div slot="description" class="tooltip-description">
-                    <p>Casting <strong>"Stasis"</strong> on yourself no longer causes the character to take damage or receive debuffs when the effect expires.</p>
+                    <p>When <span class="harm">"Stasis"</span> expires or is removed after being applied to the character, it no longer harms them
+                        and also activates <span class="buff">"Intangibility"</span> for <strong>1</strong> turn,
+                        making them untargetable by strikes, shots, and spells.</p>
 
-                    <p>While in <strong>"Stasis"</strong>, the character's cooldowns are no longer frozen,
-                        and the effect itself grants major bonuses to their <span class="buff">Arcanistics Power</span> and <span class="buff">Miracle Chance</span>.</p>
-
-                    <p>When the effect expires, the character will receive <span class="buff">"Between the Worlds"</span> for one turn,
-                        making them untargetable by aimed attacks and spells.</p>
+                    <p>While <span class="harm">"Stasis"</span> is active on the character, grants the effect <span class="buff">+50%</span> Arcanistics Power,
+                        <span class="buff">+25%</span> Miracle Chance, and prevents it from <strong>freezing</strong> cooldowns.</p>
                 </div>
             </ability-pick>
         </ability-tree>


### PR DESCRIPTION
This change updates the following Arcanistics skill descriptions:

- Wormhole (Closes #130)
- Dimensional Shift (Closes #131)
- Arcane Might (Closes #132)
- Time Echo (Closes #133)
-  Schism (Closes #134)
- Transcendental Anchoring (Closes #135)
- Aether Shield (Closes #136)
- Astral Tides (Closes #137)
- Mana Crystal (Closes #138)
- Stasis (Closes #139)
- Phantasm (Closes #140)
- Entropy Flare (Closes #141)
- Aether Harmony (Closes #142)
- Beyond the Veil (Closes #143)

Closes #129 