### PR TITLE
Refund abilities regardless of order and remove level-30 cap

### DIFF
--- a/components/ability-pick/ability-pick.js
+++ b/components/ability-pick/ability-pick.js
@@ -1,6 +1,12 @@
 import Character from '../../components/stat-formula/character.js';
 
-class AbilityPick extends HTMLElement {
+/**
+ * @class AbilityPick
+ * @extends HTMLElement
+ * 
+ * Represents an obtainable ability in the talent tree.
+ */
+export class AbilityPick extends HTMLElement {
   /**
    * @type {Character}
    */
@@ -15,6 +21,7 @@ class AbilityPick extends HTMLElement {
   #obtained = false;
   #innate = false;
   #parents = null;
+  /** @type {string[]} */
   #childIds = [];
   #image = null;
   #overlayText = null;
@@ -199,7 +206,7 @@ class AbilityPick extends HTMLElement {
     if (!attribute) return null;
 
     function parseAttribute(value) {
-        // Handle OR (`|`) first, as it has lower precedence than AND.
+        // Handle OR (`|`) first, since it is the lowest-precedence operator.
         if (value.includes('|')) {
             return {
                 type: 'OR',
@@ -223,7 +230,7 @@ class AbilityPick extends HTMLElement {
   }
 
   setLevelObtainedAt(level) {
-    if (!level) {
+    if (level == null) {
       this.#overlayText.innerHTML = ``;
       return;
     }
@@ -525,6 +532,9 @@ class AbilityPick extends HTMLElement {
     return this.#innate;
   }
 
+  /**
+   * @returns {string[]}
+   */
   get childIds() {
     return this.#childIds;
   }

--- a/components/ability-tree/ability-tree.js
+++ b/components/ability-tree/ability-tree.js
@@ -1,6 +1,19 @@
-class AbilityTree extends HTMLElement {
+import { AbilityPick } from '../../components/ability-pick/ability-pick.js';
+
+/**
+ * @class AbilityTree
+ * @extends HTMLElement
+ * 
+ * Represents a single talent tree like swords or athletics.
+ */
+export class AbilityTree extends HTMLElement {
   #display = '';
+
+  /**
+   * @type {Map<string, AbilityPick>}
+   */
   #abilityMap = new Map();
+
   constructor() {
     super();
     
@@ -24,6 +37,7 @@ class AbilityTree extends HTMLElement {
   }
 
   #buildAbilityMap() {
+    /** @type {NodeListOf<AbilityPick} */
     const abilities = this.querySelectorAll('ability-pick');
     abilities.forEach(ability => {
       this.#abilityMap.set(ability.getAttribute('id'), ability);
@@ -64,21 +78,19 @@ class AbilityTree extends HTMLElement {
     return checkParentType(ability.parents);
   }
 
-  #canRefund(id) {
-    const ability = this.#abilityMap.get(id);
+  /**
+   * Returns true if an ability can be refunded.
+   * 
+   * @param {string} abilityId 
+   * @returns {boolean}
+   */
+  #canRefund(abilityId) {
+    const ability = this.#abilityMap.get(abilityId);
     if (!ability) return false;
-
-    return ability.childIds.every(childId => {
-      const child = this.#abilityMap.get(childId);
-      // If the child is not obtained, we can refund.
-      if (!child || !child.obtained) return true; 
-
-      // If the child has no parents or parents use AND logic, we block refund.
-      if (!child.parents || child.parents.type === 'AND') return false;
-
-      // If the child's parents use OR logic, we check if any other parent is obtained and in that case, refund is allowed.
-      return child.parents.values.some(parentId => parentId !== id && this.#abilityMap.get(parentId)?.obtained);
-    });
+    if (!ability.obtained) return false;
+    if (ability.innate) return false;
+    
+    return true;
   }
 
   #handleAbilityPickObtain(e) {
@@ -105,6 +117,7 @@ class AbilityTree extends HTMLElement {
     }
   }
 
+  /** @returns {Map<string, AbilityPick>} */
   getAbilityMap() {
     return this.#abilityMap;
   }

--- a/talent-calculator.js
+++ b/talent-calculator.js
@@ -1,6 +1,6 @@
 import './components/ability-tree-selector/ability-tree-selector.js';
-import './components/ability-tree/ability-tree.js';
-import './components/ability-pick/ability-pick.js';
+import { AbilityTree } from './components/ability-tree/ability-tree.js';
+import { AbilityPick } from './components/ability-pick/ability-pick.js';
 import './components/stat-formula/stat-formula.js';
 import './components/tooltip-description/tooltip-description.js';
 
@@ -9,11 +9,21 @@ import Character from './components/stat-formula/character.js';
 import { APP_VERSION, APP_URL, REPO_NAME, REPO_OWNER } from './version.js';
 
 class TalentCalculator extends HTMLElement {
-  /**
-   * @type {Character}
-   */
+  /** @type {Character} */
   #character = null;
+
+  /**
+   * Maps tree IDs (e.g. swords) to AbilityTree elements.
+   * @type {Map<string, AbilityTree>}
+   */
   #treeMap = new Map();
+
+  /**
+   * Maps ability IDs (e.g. swords-1) to AbilityPick elements.
+   * @type {Map<string, AbilityPick>}
+   */
+  #abilityPickMap = new Map();
+
   #level = 1;
   #abilityPoints = 2;
   #abilityStack = [];
@@ -32,15 +42,25 @@ class TalentCalculator extends HTMLElement {
   }
 
   #buildTreeMap() {
+    /** @type {NodeListOf<AbilityTree} */
     const trees = this.querySelectorAll('ability-tree');
     trees.forEach(tree => {
       this.#treeMap.set(tree.getAttribute('id'), tree);
     });
   }
 
+  #buildAbilityPickMap() {
+    for (const tree of this.#treeMap.values()) {
+      for (const [id, abilityPick] of tree.getAbilityMap()) {
+        this.#abilityPickMap.set(id, abilityPick);
+      }
+    }
+  }
+
   connectedCallback() {
     this.#gtag('set', { 'app_version': APP_VERSION });
     this.#buildTreeMap();
+    this.#buildAbilityPickMap();
 
     const exportButton = this.querySelector('#export-button');
     this.#buttonClickWithAnalytics(exportButton, () => {
@@ -184,14 +204,11 @@ class TalentCalculator extends HTMLElement {
     const tree = this.#treeMap.get(treeId);
     const ability = tree.getAbilityMap().get(abilityId);
     ability.obtained = true;
-    ability.setLevelObtainedAt(this.#level);
 
     this.#abilityStack.push(abilityId);
-    this.#abilityPoints--;
-    // When ability points become zero, we level up automatically for the user's convenience.
-    if (this.#abilityPoints === 0) {
-      this.#levelUp();
-    }
+    this.#setLevelAndAbilityPoints();
+    this.#setLevelOrderForObtainedAbilities();
+    
     if (abilityId === 'shields-8') this.#character.retaliation = 1.5;
     this.#updateShieldFormulas();
     this.#updateOpenWeaponSkills(abilityId, () => this.#character.openWeaponSkills++);
@@ -200,25 +217,90 @@ class TalentCalculator extends HTMLElement {
   #handleAbilityTreeRefund(e) {
     const abilityId = e.detail.id;
     const treeId = e.detail.treeId;
-    // We only allow to refund the last obtained ability from the top of the stack.
-    const lastAbilityId = this.#abilityStack[this.#abilityStack.length - 1];
-    if (lastAbilityId !== abilityId) {
-      return;
-    }
 
     const tree = this.#treeMap.get(treeId);
     const ability = tree.getAbilityMap().get(abilityId);
     ability.obtained = false;
     ability.setLevelObtainedAt();
 
-    this.#abilityStack.pop();
-    this.#abilityPoints++;
-    if (this.#abilityPoints === 2) {
-      this.#levelDown();
-    }
+    this.#removeFromAbilityStackIncludingChildren(abilityId);
+    this.#setLevelAndAbilityPoints();
+    this.#setLevelOrderForObtainedAbilities();
+    
     if (abilityId === 'shields-8') this.#character.retaliation = 1;
     this.#updateShieldFormulas();
     this.#updateOpenWeaponSkills(abilityId, () => this.#character.openWeaponSkills--);
+  }
+
+  /**
+   * The level and ability points are calculated by looping the obtained abilities and implementing the following rules:
+   * 
+   * - The character starts at level 1 with 2 ability points.
+   * - Every level up, the character gets 1 ability point.
+   * - When an ability is obtained, the character spends 1 ability point.
+   * - For the user's convenience, when ability points reach 0, the character levels up automatically.
+   */
+  #setLevelAndAbilityPoints() {
+    let abilityPoints = 2;
+    let level = 1;
+    this.#abilityStack.forEach(abilityId => {
+      abilityPoints--;
+      if (abilityPoints === 0) {
+        level++;
+        abilityPoints++;
+      }
+    });
+    this.#level = level;
+    this.#abilityPoints = abilityPoints;
+  }
+
+  /**
+   * @param {string} abilityId 
+   */
+  #removeFromAbilityStackIncludingChildren(abilityId) {
+    const rootAbilityPick = this.#abilityPickMap.get(abilityId);
+    if (!rootAbilityPick) return;
+
+    // Gather all ability IDs to remove in a Set, including children and their children.
+    const abilityIdsToRemove = new Set([abilityId]);
+
+    // Use a stack to keep track of any children to be removed.
+    const stack = [rootAbilityPick];
+    while (stack.length > 0) {
+      const pick = stack.pop();
+
+      for (const childId of pick.childIds) {
+        if (!this.#abilityStack.includes(childId)) continue; // We only consider children that are currently obtained.
+        if (abilityIdsToRemove.has(childId)) continue; // Avoid looping the same children.
+
+        abilityIdsToRemove.add(childId);
+
+        const childPick = this.#abilityPickMap.get(childId);
+        if (childPick) stack.push(childPick);
+      }
+    }
+
+    this.#abilityStack = this.#abilityStack.filter(id => !abilityIdsToRemove.has(id));
+
+    for (const id of abilityIdsToRemove) {
+      const abilityPick = this.#abilityPickMap.get(id);
+      if (!abilityPick) continue;
+      abilityPick.obtained = false;
+      abilityPick.setLevelObtainedAt();
+    }
+  }
+
+  /**
+   * Adjust the level order overlay of all abilities. 
+   * Useful when we refund one or more abilities.
+   */
+  #setLevelOrderForObtainedAbilities() {
+    let levelOrder = 0;
+    this.#abilityStack.forEach(abilityId => {
+      const abilityPick = this.#abilityPickMap.get(abilityId);
+      abilityPick.setLevelObtainedAt(levelOrder === 0 ? 1 : levelOrder);
+      levelOrder++;
+    });
   }
 
   #updateShieldFormulas() {
@@ -260,6 +342,7 @@ class TalentCalculator extends HTMLElement {
   }
 
   #showLevelOrderOverlay(show) {
+    /** @type {NodeListOf<AbilityPick>} */
     const abilities = this.querySelectorAll('ability-pick');
     abilities.forEach(ability => {
       if (show) {


### PR DESCRIPTION
- Abilities can now be refunded regardless of order (previously only the last obtained ability could be refunded).
- Removed the level-30 cap to support builds with additional AP gains (e.g. Hilda, Dirwin, Mahir).
- Introduce JSDoc type hints in new and modified code.

Closes #156 