### PR TITLE
Fix stray quote in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -2709,7 +2709,7 @@
                 range=1
                 energy="0"
                 cooldown="0"
-                requires="Requires a sword, an axe, a dagger, a two-handed sword, or a two-handed axe.""
+                requires="Requires a sword, an axe, a dagger, a two-handed sword, or a two-handed axe."
                 tooltip-right>
                 <div slot="description" class="tooltip-description">
                     <p>Carves the targeted animal carcass for meat.</p>


### PR DESCRIPTION
Fixes a stray double quote that caused invalid HTML.

No functional changes beyond correcting the markup.
