### PR TITLE
Show "New" badge for updated releases

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,9 @@
             <header class="app-header">
                 <a id="stoneshard-logo-link" href="#" title="Reload the app"><img class="stoneshard-logo" src="img/stoneshard-logo.png" alt="Stoneshard Logo" width="160" height="105"></a>
                 <h1>Talent Calculator</h1>
-                <a id="app-version-link" href="#" target="_blank" rel="noopener noreferrer external" title="View the latest releases and what changed"></a>
+                <a id="app-version-link" href="#" target="_blank" rel="noopener noreferrer external" title="View the latest releases and what changed">
+                    <span id="app-version-text"></span><span id="new-version-badge" hidden>New</span>
+                </a>
             </header>
             <nav>
                 <a id="sponsor-link" class="button" href="#" target="_blank" rel="noopener noreferrer external" title="Become a sponsor of this project"><span class="heart">♡</span>Sponsor</a>

--- a/main.css
+++ b/main.css
@@ -55,6 +55,37 @@ nav {
 .app-header #app-version-link {
   color: #ffffff;
   font-size: 13px;
+  text-decoration: none;
+}
+
+#app-version-link #app-version-text {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+#new-version-badge {
+  color: #f6bb15;
+  display: inline-block;
+  margin-left: 0.4em;
+  padding: 0.1rem 0.4rem;
+  font-size: 0.85em;
+  line-height: 1.4;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  vertical-align: baseline;
+  user-select: none;
+}
+
+#new-version-badge[hidden] {
+  display: none !important;
+}
+
+#app-version-link #new-version-badge {
+  opacity: 0.85;
+}
+
+#app-version-link:hover #new-version-badge {
+  opacity: 1;
 }
 
 .calculator-controls {

--- a/talent-calculator.js
+++ b/talent-calculator.js
@@ -170,9 +170,28 @@ class TalentCalculator extends HTMLElement {
     const issuesUrl = `${repoUrl}/issues`;
     const manualUrl = `${repoUrl}?tab=readme-ov-file#usage`;
 
+
+    const versionText = this.querySelector('#app-version-text');
+    if (versionText) {
+     versionText.textContent = APP_VERSION;
+    }
+
+    const storageKey = "stoneshard-tc:lastSeenRelease";
+    const newVersionBadge = this.querySelector("#new-version-badge");
+    if (newVersionBadge) {
+      const lastSeen = localStorage.getItem(storageKey);
+
+      // Show New badge on version change but not on first visit.
+      newVersionBadge.hidden = (lastSeen === null) || (lastSeen === APP_VERSION);
+    }
+
     const versionLink = this.querySelector('.app-header #app-version-link');
-    versionLink.innerHTML = `${APP_VERSION}`;
-    this.#setLinkWithAnalytics(versionLink, versionUrl);
+    if (versionLink) {
+      this.#setLinkWithAnalytics(versionLink, versionUrl, () => {
+        localStorage.setItem(storageKey, APP_VERSION);
+        if (newVersionBadge) newVersionBadge.hidden = true;
+      });
+    }
 
     const sponsorLink = this.querySelector('nav #sponsor-link');
     this.#setLinkWithAnalytics(sponsorLink, sponsorUrl);


### PR DESCRIPTION
## Overview
Adds a small **“New”** badge next to the app version link when a user returns after a new release has been deployed.

## Behavior
- Badge is shown only when `APP_VERSION` has changed since the user’s last visit (stored in `localStorage`).
- Badge is hidden on first visit.
- Clicking the version link marks the release as seen and hides the badge.

Closes #217