### PR TITLE
Sync tooltips, formulas and ability attributes with latest game data

### DIFF
--- a/index.html
+++ b/index.html
@@ -1758,10 +1758,11 @@
                 <div slot="description" class="tooltip-description">
                     <p><strong>Repositions</strong> to an adjacent tile,
                         replenishes <strong><stat-formula>math_round(2 * Vitality)</stat-formula>%</strong> Max Block Power,
-                        and reduces the ability tree's cooldowns by <span class="buff">1</span> turn
+                        and reduces the cooldowns of the ability tree's other skills by <span class="buff">1</span> turn
                         for each visible enemy within <strong>3</strong> tiles.</p>
 
-                    <p>Activates <span class="buff">"Regroup"</span> for <strong>10</strong> turns:</p>
+                    <p>Activates <span class="buff">"Regroup"</span>
+                        for <strong>10</strong> turns:</p>
 
                     <p><span class="buff">+5%</span> Block Chance<br>
                         <span class="buff">+5%</span> Max Block Power<br>
@@ -1769,7 +1770,7 @@
                         <span class="buff">+5%</span> Counter Chance</p>
 
                     <p>Grants an extra stack of the effect (up to <strong>IV</strong>)
-                        for each ability tree's skill that was on cooldown before its activation.</p>
+                        for each reduced cooldown.</p>
                 </div>
             </ability-pick>
             <ability-pick id="spears-10"                               parents="spears-7"
@@ -1851,12 +1852,12 @@
                 tooltip-bottom-left>
                 <div slot="description" class="tooltip-description">
                     <p>Killing enemies with melee strikes activates <span class="buff">"Taking Aim"</span>
-                        for <strong>1</strong> turn the next time the character switches to a loadout with an equipped <strong>ranged weapon</strong>
+                        for <strong>1</strong> turn the next time the character switches to the loadout with an equipped <strong>ranged weapon</strong>
                         (if the weapon is a <strong>crossbow</strong>,
                         also instantly reloads it).</p>
 
                     <p>If equipped with a <strong>ranged weapon</strong>,
-                        switching to another loadout doesn't take a turn.</p>
+                        switching to the loadout with a <strong>melee weapon</strong> doesn't take a turn.</p>
 
                     <p>Reduces the chance of bolts
                         and arrows breaking upon hitting their target (from <span class="harm">50%</span> to <span class="harm">25%</span>).</p>
@@ -2303,8 +2304,8 @@
                 maneuver
                 target="No Target"
                 range="1"
-                energy="12"
-                cooldown="12"
+                energy="14"
+                cooldown="14"
                 modifiers="Vitality"
                 requires="Requires a shield"
                 tooltip-mid-right>
@@ -2379,7 +2380,7 @@
                 target="Target Object"
                 range="1"
                 energy="12"
-                cooldown="8"
+                cooldown="10"
                 modifiers="Strength, Agility, Perception, Willpower"
                 requires="Requires a staff"
                 tooltip-bottom-right>
@@ -2549,7 +2550,7 @@
                 target="Target Object"
                 range="1"
                 energy="14"
-                cooldown="10"
+                cooldown="12"
                 requires="Requires dual weapons"
                 tooltip-right>
                 <div slot="description" class="tooltip-description">
@@ -3179,8 +3180,8 @@
                 maneuver
                 target="No Target"
                 range="1"
-                energy="16"
-                cooldown="24"
+                energy="20"
+                cooldown="28"
                 tooltip-right>
                 <div slot="description" class="tooltip-description">
                     <p>Activates <strong>5</strong> stacks of <span class="buff">"Offensive Tactic"</span>
@@ -3213,8 +3214,8 @@
                 maneuver
                 target="No Target"
                 range="1"
-                energy="16"
-                cooldown="24"
+                energy="20"
+                cooldown="28"
                 tooltip-right>
                 <div slot="description" class="tooltip-description">
                     <p>Activates <strong>5</strong> stacks of <span class="buff">"Defensive Tactic"</span>
@@ -3267,7 +3268,7 @@
                 target="Target Object"
                 range="2"
                 energy="26"
-                cooldown="16"
+                cooldown="18"
                 modifiers="Strength, Agility, Perception, Willpower"
                 tooltip-top-right>
                 <div slot="description" class="tooltip-description">
@@ -3324,7 +3325,7 @@
                 key="Against_the_Odds"
                 maneuver
                 target="No Target"
-                energy="10"
+                energy="12"
                 cooldown="60"
                 tooltip-top-left>
                 <div slot="description" class="tooltip-description">
@@ -3443,7 +3444,7 @@
                 label="Leg Sweep"
                 key="Sweep"
                 maneuver
-                energy="10"
+                energy="12"
                 cooldown="8"
                 target="Target Area"
                 range="1"
@@ -3556,8 +3557,8 @@
                 label="Sudden Lunge"
                 key="Sudden_Strike"
                 attack
-                energy="14"
-                cooldown="12"
+                energy="20"
+                cooldown="14"
                 target="Target Object"
                 range="1"
                 modifiers="Agility, Perception"
@@ -3711,7 +3712,7 @@
                 label="Seal of Finesse"
                 key="Seal_of_Finesse"
                 spell
-                energy="20" 
+                energy="18" 
                 cooldown="16"
                 target="No Target"
                 backfire-chance="-50"
@@ -3815,8 +3816,8 @@
                 label="Seal of Insight"
                 key="Seal_of_Insight"
                 spell
-                energy="12" 
-                cooldown="8"
+                energy="20" 
+                cooldown="12"
                 target="No Target"
                 backfire-chance="5"
                 backfire-damage-type="arcane"
@@ -3864,7 +3865,7 @@
                 label="Seal of Cleansing"
                 key="Seal_of_Cleansing"
                 spell
-                energy="20"
+                energy="24"
                 cooldown="24"
                 target="Target Object"
                 range="6"
@@ -3938,8 +3939,8 @@
                 label="Seal of Reflection"
                 key="Seal_of_Reflection"
                 spell
-                energy="40"
-                cooldown="40"
+                energy="42"
+                cooldown="36"
                 target="Target Object"
                 range="6"
                 backfire-chance="15"
@@ -5009,7 +5010,7 @@
                 target="Target Object"
                 range="6"
                 energy="60"
-                cooldown="20"
+                cooldown="22"
                 backfire-chance="30"
                 backfire-damage-type="shock"
                 armor-penetration="45"
@@ -5069,7 +5070,7 @@
                 target="Target Tile"
                 range="4"
                 energy="48"
-                cooldown="24"
+                cooldown="26"
                 backfire-chance="25"
                 backfire-damage-type="shock"
                 armor-penetration="20"
@@ -5113,9 +5114,9 @@
                 <div slot="description" class="tooltip-description">
                     <p>Each <strong>third</strong> use of the ability tree's spells
                         with <strong><stat-formula>math_round(75 * ((Magic_Power + Electromantic_Power) / 100))</stat-formula>%</strong> chance applies <span class="harm">"Resonance"</span>
-                        for <strong>3</strong> turns to a random target within Vision without this effect.</p>
+                        for <strong>3</strong> turns to a random enemy within Vision without this effect.</p>
 
-                    <p>If there are no such targets,
+                    <p>If there are no such enemies,
                         prolongs the duration of <span class="harm">"Resonance"</span> or <span class="harm">"Impulse"</span> affecting a random <span class="shock">Resonating</span> target within Vision by <strong>3</strong> turns.</p>
                 </div>
             </ability-pick>
@@ -5185,19 +5186,25 @@
                 modifiers="Magic Power, Arcanistic Power, Bonus Range"
                 tooltip-right>
                 <div slot="description" class="tooltip-description">
-                    <p>Applies the target with <span class="harm">"Wormhole"</span> for <strong>3</strong> turns and marks its tile.</p>
+                    <p>Applies the target with <span class="harm">"Wormhole"</span>
+                        for <strong>3</strong> turns
+                        and marks its tile.</p>
 
-                    <p>When the effect expires or is removed, <strong>teleports</strong> the target to the marked tile,
-                        dealing <span class="arcane"><stat-formula>(5 * (1 + Arcanistic_Power / 100) * Magic_Power / 100)</stat-formula> Arcane Damage</span>.</p>
+                    <p>When the effect expires or is removed,
+                        <strong>teleports</strong> the target to the marked tile,
+                        dealing <span class="arcane"><stat-formula>(8 * (1 + Arcanistic_Power / 100) * Magic_Power / 100)</stat-formula> Arcane Damage</span>.</p>
 
-                    <p>If the marked tile is occupied, <strong>teleports</strong> the target to the closest empty tile,
-                        dealing additional <span class="arcane"><stat-formula>(11 * (1 + Arcanistic_Power / 100) * Magic_Power / 100)</stat-formula> Arcane Damage</span>
-                        and with <strong><stat-formula>(60 * ((Magic_Power + Arcanistic_Power) / 100))</stat-formula>%</strong> chance <strong>Stunning</strong> it.</p>
+                    <p>If the marked tile is occupied,
+                        <strong>teleports</strong> the target to the closest empty tile,
+                        dealing additional <span class="arcane"><stat-formula>(12 * (1 + Arcanistic_Power / 100) * Magic_Power / 100)</stat-formula> Arcane Damage</span> and
+                        with <strong><stat-formula>(60 * ((Magic_Power + Arcanistic_Power) / 100))</stat-formula>%</strong> chance <strong>Stunning</strong> it.</p>
 
                     <p>While <span class="harm">"Wormhole"</span> is active,
-                        the spell doesn't go on cooldown and can be used again without spending Energy to remove the effect from the target.</p>
+                        the spell doesn't go on cooldown
+                        and can be used again without spending Energy to remove the effect from the target.</p>
 
-                    <p>The spell can't be used on giant or stationary targets and doesn't harm the caster.</p>
+                    <p>The spell can't be used on giant or stationary targets
+                        and doesn't harm the caster.</p>
                 </div>
             </ability-pick>
             <ability-pick id="arcanistics-2"  children="arcanistics-5 arcanistics-6"
@@ -5208,28 +5215,36 @@
                 spell
                 target="Target Object"
                 range="5"
-                energy="12"
-                cooldown="6"
+                energy="10"
+                cooldown="8"
                 backfire-chance="10"
                 backfire-damage-type="arcane"
                 armor-penetration="60"
                 modifiers="Magic Power, Arcanistic Power, Willpower, Bonus Range"
                 tooltip-right>
                 <div slot="description" class="tooltip-description">
-                    <p>Marks two targets, then <strong>teleports</strong> them, swapping their positions.</p>
+                    <p>Marks two targets,
+                        then <strong>teleports</strong> them,
+                        swapping their positions
+                        and dealing <span class="arcane"><stat-formula>(5 * (1 + Arcanistic_Power / 100) * Magic_Power / 100)</stat-formula> Arcane Damage</span>.</p>
 
-                    <p>Deals <span class="arcane"><stat-formula>(2 * (1 + Arcanistic_Power / 100) * Magic_Power / 100)</stat-formula> Arcane Damage</span>
-                        to both targets for each tile of distance between them,
-                        and with <strong><stat-formula>(80 * ((Magic_Power + Arcanistic_Power) / 100))</stat-formula>%</strong> chance
-                        <strong>Confuses</strong> them for <strong>3</strong> turns or <strong>Dazes</strong> for <strong>2</strong> turns.</p>
+                    <p>Also deals <span class="arcane"><stat-formula>(1 * (1 + Arcanistic_Power / 100) * Magic_Power / 100)</stat-formula> Arcane Damage</span> to both targets
+                        for each tile of distance between them,
+                        and
+                        with <strong><stat-formula>(80 * ((Magic_Power + Arcanistic_Power) / 100))</stat-formula>%</strong> chance <strong>Confuses</strong> them
+                        for <strong>3</strong> turns or <strong>Dazes</strong>
+                        for <strong>2</strong> turns.</p>
 
                     <p>Applies both targets with <span class="harm"><stat-formula>(-0.5 * WIL)</stat-formula>%</span> Weapon Damage,
                         <span class="harm"><stat-formula>(-0.5 * WIL)</stat-formula>%</span> Accuracy,
-                        and <span class="harm"><stat-formula>(0.5 * WIL)</stat-formula>%</span> Fumble Chance for <strong>3</strong> turns.</p>
+                        and <span class="harm"><stat-formula>(0.5 * WIL)</stat-formula>%</span> Fumble Chance
+                        for <strong>3</strong> turns.</p>
 
                     <p>The effect stacks up to <strong>2</strong> times.</p>
 
-                    <p>The spell can't be used on giant or stationary targets, doesn't harm the caster, and doesn't apply penalties to their allies.</p>
+                    <p>The spell can't be used on giant or stationary targets,
+                        doesn't harm the caster,
+                        and doesn't apply penalties to their allies.</p>
                 </div>
             </ability-pick>
             <ability-pick id="arcanistics-3"  children="arcanistics-6 arcanistics-7"
@@ -5240,17 +5255,20 @@
                 passive
                 tooltip-right>
                 <div slot="description" class="tooltip-description">
-                    <p>Dealing <span class="arcane">Arcane Damage</span> with strikes, shots, and spells
-                        grants <span class="buff">+2%</span> Accuracy,
+                    <p>Dealing <span class="arcane">Arcane Damage</span> with strikes,
+                        shots,
+                        and spells grants <span class="buff">+2%</span> Accuracy,
                         <span class="buff">-2%</span> Fumble Chance,
                         <span class="buff">-2%</span> Backfire Chance,
                         <span class="buff">+2%</span> Crit Chance,
-                        and <span class="buff">+2%</span> Miracle Chance for <strong>4</strong> turns.</p>
+                        and <span class="buff">+2%</span> Miracle Chance
+                        for <strong>4</strong> turns.</p>
 
                     <p>The effect stacks up to <strong>3</strong> times.</p>
 
-                    <p><strong>Teleporting</strong> grants <span class="buff">+1</span> Range to <strong>Arcanistics</strong> spells for <strong>4</strong> turns
-                        and <span class="buff">-15%</span> Backfire Damage Change for <strong>2</strong> turns.</p>
+                    <p><strong>Teleporting</strong> grants <span class="buff">+1</span> Range to <strong>Arcanistics</strong> spells
+                        and <span class="buff">-5%</span> Backfire Damage Change
+                        for <strong>4</strong> turns.</p>
                 </div>
             </ability-pick>
             <ability-pick id="arcanistics-4"                 parents="arcanistics-1"
@@ -5262,11 +5280,11 @@
                 tooltip-right>
                 <div slot="description" class="tooltip-description">
                     <p>When <span class="harm">"Wormhole"</span> expires or is removed after being applied to the character,
-                        replenishes <strong>33%</strong> Health and Energy lost over the course of the effect.</p>
+                        replenishes <strong>50%</strong> Health
+                        and Energy lost over the course of the effect.</p>
 
                     <p>When <span class="harm">"Wormhole"</span> expires or is removed after being applied to an enemy,
-                        deals additional <span class="arcane">Arcane Damage</span> equal to <strong>33%</strong> of the damage they received
-                        over the course of the effect.</p>
+                        deals additional <span class="arcane">Arcane Damage</span> equal to <strong>33%</strong> of the damage they received over the course of the effect.</p>
                 </div>
             </ability-pick>
             <ability-pick id="arcanistics-5"  children="arcanistics-8 arcanistics-9"  parents="arcanistics-1|arcanistics-2"
@@ -5285,16 +5303,14 @@
                 modifiers="Magic Power, Arcanistic Power, Bonus Range"
                 tooltip-right>
                 <div slot="description" class="tooltip-description">
-                    <p>Deals <span class="arcane"><stat-formula>(10 * (1 + Arcanistic_Power / 100) * Magic_Power / 100)</stat-formula> Arcane Damage</span>
-                        to a <strong>5x5</strong> tile area (except the central tile)
-                        and with <strong><stat-formula>(40 * ((Magic_Power + Arcanistic_Power) / 100))</stat-formula>%</strong> chance
-                        <strong>Staggers</strong> or <strong>Immobilizes</strong> all affected targets.</p>
+                    <p>Deals <span class="arcane"><stat-formula>(11 * (1 + Arcanistic_Power / 100) * Magic_Power / 100)</stat-formula> Arcane Damage</span> to a <strong>5x5</strong> tile area (except the central tile) and
+                        with <strong><stat-formula>(40 * ((Magic_Power + Arcanistic_Power) / 100))</stat-formula>%</strong> chance <strong>Staggers</strong> or <strong>Immobilizes</strong> all affected targets.</p>
 
-                    <p>With <strong><stat-formula>(100 * ((Magic_Power + Arcanistic_Power) / 100))</stat-formula>%</strong> chance
-                        <strong>knocks</strong> back the targets adjacent to the area's center
+                    <p>With <strong><stat-formula>(100 * ((Magic_Power + Arcanistic_Power) / 100))</stat-formula>%</strong> chance <strong>knocks</strong> back the targets adjacent to the area's center
                         and <strong>pulls</strong> the targets that are <strong>1</strong> tile away from it.</p>
 
-                    <p>The spell doesn't harm the caster, aside from <span class="arcane">Arcane Damage</span>.</p>
+                    <p>The spell doesn't harm the caster,
+                        aside from <span class="arcane">Arcane Damage</span>.</p>
                 </div>
             </ability-pick>
             <ability-pick id="arcanistics-6"  children="arcanistics-9 arcanistics-10" parents="arcanistics-2|arcanistics-3"
@@ -5326,21 +5342,27 @@
                 modifiers="Magic Power, Arcanistic Power, Willpower"
                 tooltip-left>
                 <div slot="description" class="tooltip-description">
-                    <p>Activates <span class="buff">"Aether Shield"</span> for <strong>3</strong> turns:</p>
+                    <p>Activates <span class="buff">"Aether Shield"</span>
+                        for <strong>2</strong> turns (<strong>+1</strong> turn
+                        for each other learned <strong>Arcanistics</strong> spell):</p>
 
                     <p><span class="buff"><stat-formula>(15 + 1.5 * WIL)</stat-formula>%</span> Control Resistance<br>
                         <span class="buff"><stat-formula>(15 + 1.5 * WIL)</stat-formula>%</span> Move Resistance<br>
                         <span class="buff"><stat-formula>(15 + 1.5 * WIL)</stat-formula>%</span> Bleed Resistance<br>
                         <span class="buff"><stat-formula>(-((10 + 0.5 * WIL)))</stat-formula>%</span> Damage Taken<br>
-                        Replenishes Energy for <strong>33%</strong> of the damage received.<br>
-                        <strong>Destroys</strong> all physical and magical projectiles (including thrown items) that would hit the caster,
-                        preventing their damage and effects.<br>
-                        <strong>Colliding</strong> with targets deals additional <span class="arcane">Arcane Damage</span> to them.</p>
+                        Replenishes Energy
+                        for <strong>20%</strong> of the damage received.<br>
+                        <strong>Destroys</strong> all physical
+                        and magical projectiles (including thrown items) that would hit the caster,
+                        preventing their damage
+                        and effects.</p>
+
+                    <p><strong>Teleporting</strong> prolongs the effect's duration by <span class="buff">3</span> turns (up to <strong>8</strong>),
+                        and each destroyed projectile reduces it by <strong>1</strong> turn.</p>
 
                     <p>While affected by <span class="buff">"Aether Shield"</span>,
-                        <strong>teleporting</strong> prolongs the effect's duration by <span class="buff">3</span> turns (up to <strong>6</strong>),
-                        and grants all strikes and shots
-                        <span class="arcane"><stat-formula>(0.1 * WIL * (1 + Arcanistic_Power / 100) * Magic_Power / 100)</stat-formula> Arcane Damage</span>
+                        <strong>teleporting</strong> also grants all strikes
+                        and shots <span class="arcane"><stat-formula>(0.1 * WIL * (1 + Arcanistic_Power / 100) * Magic_Power / 100)</stat-formula> Arcane Damage</span>
                         for <strong>4</strong> turns.</p>
 
                     <p>The effect stacks up to <strong>2</strong> times.</p>
@@ -5354,15 +5376,15 @@
                 passive
                 tooltip-top-right>
                 <div slot="description" class="tooltip-description">
-                    <p>If <strong>"Schism"</strong>
-                        (or <strong>"Arcane Tether"</strong> of the summoned <strong>Phantasm</strong>) successfully <strong>knocks</strong> back
-                        or <strong>pulls</strong> the target, applies it with <span class="harm">-10%</span> Magic Resistance
-                        and <span class="harm">-10%</span> Arcane Resistance for <strong>3</strong> turns.</p>
+                    <p>If <strong>"Schism"</strong> (or <strong>"Arcane Tether"</strong> of the summoned <strong>Phantasm</strong>) successfully <strong>knocks</strong> back or <strong>pulls</strong> the target,
+                        applies it with <span class="harm">-10%</span> Magic Resistance
+                        and <span class="harm">-10%</span> Arcane Resistance
+                        for <strong>3</strong> turns.</p>
 
                     <p>The effect stacks up to <strong>2</strong> times.</p>
 
                     <p>If these spells fail to <strong>knock</strong> back or <strong>pull</strong> the target,
-                        deals <span class="arcane"><stat-formula>(5 * (1 + Arcanistic_Power / 100))</stat-formula> Arcane Damage</span> to it instead.</p>
+                        deals <span class="arcane"><stat-formula>(4 * (1 + Arcanistic_Power / 100))</stat-formula> Arcane Damage</span> to it instead.</p>
                 </div>
             </ability-pick>
             <ability-pick id="arcanistics-9" children="arcanistics-12 arcanistics-13"              parents="arcanistics-5 arcanistics-6"
@@ -5373,29 +5395,35 @@
                 spell
                 target="Target Tile"
                 range="3"
-                energy="32"
-                cooldown="20"
+                energy="34"
+                cooldown="24"
                 backfire-chance="25"
                 backfire-damage-type="arcane"
                 modifiers="Magic Power, Arcanistic Power, Perception, Willpower, Backfire Chance, Miracle Chance, Miracle Potency, Bonus Range"
                 tooltip-bottom>
                 <div slot="description" class="tooltip-description">
-                    <p>Summons a <strong>Mana Crystal</strong> on the targeted tile, which persists for <strong>8</strong> turns.</p>
+                    <p>Summons a <strong>Mana Crystal</strong> on the targeted tile,
+                        which persists
+                        for <strong>8</strong> turns.</p>
 
-                    <p>Each turn, the <strong>Crystal</strong> shoots a bolt of Aether at the enemy with the lowest Health
-                        within <strong><stat-formula>4</stat-formula></strong> tiles,
+                    <p>Each turn,
+                        the <strong>Crystal</strong> shoots a bolt of Aether at the enemy with the lowest Health within <strong><stat-formula>4</stat-formula></strong> tiles,
                         dealing <span class="arcane"><stat-formula>((1 + Arcanistic_Power / 100) * 10)</stat-formula> Arcane Damage</span>
-                        with <strong><stat-formula>((-Miscast_Chance) + 100)</stat-formula>%</strong> Accuracy,
+                        with <strong><stat-formula>(75 - Miscast_Chance + 100)</stat-formula>%</strong> Accuracy,
                         <strong><stat-formula>(PRC - 10 + 10)</stat-formula>%</strong> Armor Penetration,
-                        <strong><stat-formula>(Miracle_Chance + 3)</stat-formula>%</strong> Crit Chance,
-                        and <strong><stat-formula>(Miracle_Power + 100)</stat-formula>%</strong> Crit Efficiency.</p>
+                        <strong><stat-formula>(0.5 * Miracle_Chance + 3)</stat-formula>%</strong> Crit Chance,
+                        and <strong><stat-formula>(0.5 * Miracle_Power + 100)</stat-formula>%</strong> Crit Efficiency.</p>
 
-                    <p>The offensive capabilities and Max Health of the <strong>Crystal</strong> change dynamically depending on the caster's stats.<br>
-                        The <strong>Crystal</strong> doesn't move and is immune to all effects (except <span class="harm">"Stasis"</span>
+                    <p>The offensive capabilities
+                        and Max Health of the <strong>Crystal</strong> change dynamically depending on the caster's stats,
+                        reducing with distance to the caster.<br>
+                        The <strong>Crystal</strong> doesn't move
+                        and is immune to all effects (except <span class="harm">"Stasis"</span>
                         and <span class="harm">"Wormhole"</span>).</p>
 
-                    <p>When <strong>teleported</strong>, the <strong>Crystal</strong> shoots <strong>3</strong> bolts at random enemies
-                        within <strong><stat-formula>4</stat-formula></strong> tiles, distributing them evenly.</p>
+                    <p>When <strong>teleported</strong>,
+                        the <strong>Crystal</strong> shoots <strong>3</strong> bolts at random enemies within <strong><stat-formula>4</stat-formula></strong> tiles,
+                        distributing them evenly.</p>
                 </div>
             </ability-pick>
             <ability-pick id="arcanistics-10" children="arcanistics-14" parents="arcanistics-6|arcanistics-7"
@@ -5444,31 +5472,38 @@
                 spell
                 target="Target Tile"
                 range="2"
-                energy="44"
-                cooldown="24"
+                energy="56"
+                cooldown="36"
                 backfire-chance="30"
                 backfire-damage-type="arcane"
                 modifiers="Magic Power, Arcanistic Power, Perception, Willpower, Backfire Chance, Miracle Chance, Miracle Potency, Bonus Range"
                 tooltip-right>
                 <div slot="description" class="tooltip-description">
-                    <p>Summons a <strong>Phantasm</strong> on the targeted tile, which persists for <strong>8</strong> turns.</p>
+                    <p>Summons a <strong>Phantasm</strong> on the targeted tile,
+                        which persists
+                        for <strong>8</strong> turns.</p>
 
-                    <p>Each turn, the <strong>Phantasm</strong>
-                        deals <span class="arcane"><stat-formula>((1 + Arcanistic_Power / 100) * 26)</stat-formula> Arcane Damage</span>
-                        to a random adjacent enemy with <strong><stat-formula>((-Miscast_Chance) + 110)</stat-formula>%</strong> Accuracy,
-                        <strong><stat-formula>(2 * PRC - 20 + 10)</stat-formula>%</strong> Armor Penetration,
-                        <strong><stat-formula>(Miracle_Chance + 12)</stat-formula>%</strong> Crit Chance,
-                        and <strong><stat-formula>(Miracle_Power + 120)</stat-formula>%</strong> Crit Efficiency.</p>
+                    <p>Each turn,
+                        the <strong>Phantasm</strong> deals <span class="arcane"><stat-formula>((1 + Arcanistic_Power / 100) * 26)</stat-formula> Arcane Damage</span> to a random adjacent enemy
+                        with <strong><stat-formula>((-Miscast_Chance) + 110)</stat-formula>%</strong> Accuracy,
+                        <strong><stat-formula>(PRC - 10 + 10)</stat-formula>%</strong> Armor Penetration,
+                        <strong><stat-formula>(0.5 * Miracle_Chance + 12)</stat-formula>%</strong> Crit Chance,
+                        and <strong><stat-formula>(0.5 * Miracle_Power + 120)</stat-formula>%</strong> Crit Efficiency.</p>
 
-                    <p>The offensive capabilities and Max Health of the <strong>Phantasm</strong> change dynamically depending on the caster's stats.<br>
+                    <p>The offensive capabilities
+                        and Max Health of the <strong>Phantasm</strong> change dynamically depending on the caster's stats,
+                        reducing with distance to the caster.<br>
                         The <strong>Phantasm</strong> can move within <strong>2</strong> tiles of its summoning or <strong>teleportation</strong> spot,
-                        is immune to all effects (except <span class="harm">"Stasis"</span> and <span class="harm">"Wormhole"</span>),
+                        is immune to all effects (except <span class="harm">"Stasis"</span>
+                        and <span class="harm">"Wormhole"</span>),
                         and replenishes Health upon taking <span class="arcane">Arcane Damage</span>.</p>
 
-                    <p>The <strong>Phantasm</strong> has access to the following abilities:
-                        <strong>"Arcane Tether"</strong>, which <strong>pulls</strong> enemies in,
-                        <strong>"Mana Siphon"</strong>, which steals Energy,
-                        and <strong>"Consonance"</strong>, which prolongs its summoning duration.</p>
+                    <p>The <strong>Phantasm</strong> has access to the following abilities: <strong>"Arcane Tether"</strong>,
+                        which <strong>pulls</strong> enemies in,
+                        <strong>"Mana Siphon"</strong>,
+                        which steals Energy,
+                        and <strong>"Consonance"</strong>,
+                        which prolongs its summoning duration.</p>
 
                     <p><strong>Teleporting</strong> the <strong>Phantasm</strong> instantly refreshes all its cooldowns.</p>
                 </div>
@@ -5481,14 +5516,16 @@
                 passive
                 tooltip-top>
                 <div slot="description" class="tooltip-description">
-                    <p><strong>Teleporting</strong> a <strong>Mana Crystal</strong> grants it
-                        <span class="buff">+1</span> Range, <span class="buff">+25%</span> Damage,
-                        <span class="buff">+10%</span> Accuracy, and <span class="buff">+25%</span> Damage Reflection for <strong>3</strong> turns.</p>
+                    <p><strong>Teleporting</strong> a <strong>Mana Crystal</strong> grants it <span class="buff">+1</span> Range,
+                        <span class="buff">+25%</span> Damage,
+                        <span class="buff">+10%</span> Accuracy,
+                        and <span class="buff">+25%</span> Damage Reflection
+                        for <strong>3</strong> turns.</p>
 
                     <p>The effect stacks up to <strong>2</strong> times.</p>
 
-                    <p>Each strike received by entities summoned with <strong>Arcanistics</strong>
-                        deals <span class="arcane">Arcane Damage</span> to the attacker equal to <strong>10%</strong> of the entities' Max Health.</p>
+                    <p>Each strike received by entities summoned
+                        with <strong>Arcanistics</strong> deals <span class="arcane">Arcane Damage</span> to the attacker equal to <strong>10%</strong> of the entities' Max Health.</p>
                 </div>
             </ability-pick>
             <ability-pick id="arcanistics-13"                                                                            parents="arcanistics-9"
@@ -5500,7 +5537,7 @@
                 tooltip-top>
                 <div slot="description" class="tooltip-description">
                     <p>Once per <strong>10</strong> turns, producing a miracle with <strong>"Mana Crystal"</strong>
-                        instantly refreshes the spell's cooldown and grants it <span class="buff">-30%</span> Energy Cost during the next use.</p>
+                        instantly refreshes the spell's cooldown and grants it <span class="buff">-20%</span> Energy Cost during the next use.</p>
 
                     <p>Each entity currently summoned with <strong>Arcanistics</strong> grants <span class="buff">-5%</span> Backfire Damage Change
                         and <span class="buff">+10%</span> Magic Power.</p>

--- a/tooltips/stoneshard-tooltips-and-formulas.json
+++ b/tooltips/stoneshard-tooltips-and-formulas.json
@@ -38,7 +38,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -89,7 +90,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -136,7 +138,8 @@
         "stance": "1",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -198,7 +201,8 @@
         "stance": "",
         "charge": "1",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     }
   ],
@@ -241,7 +245,8 @@
         "stance": "",
         "charge": "1",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -298,7 +303,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -355,7 +361,8 @@
         "stance": "1",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -395,7 +402,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -448,7 +456,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": "knockback"
       }
     },
     {
@@ -502,7 +511,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -563,7 +573,8 @@
         "stance": "1",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -606,7 +617,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -669,7 +681,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -710,7 +723,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -762,7 +776,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -809,7 +824,8 @@
         "stance": "1",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -870,7 +886,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     }
   ],
@@ -914,7 +931,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -968,7 +986,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -1015,7 +1034,8 @@
         "stance": "1",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -1057,7 +1077,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -1118,7 +1139,8 @@
         "stance": "",
         "charge": "1",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -1172,7 +1194,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -1224,7 +1247,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -1263,7 +1287,8 @@
         "stance": "1",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -1325,7 +1350,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -1375,7 +1401,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -1437,7 +1464,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -1477,7 +1505,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": "knockback"
       }
     },
     {
@@ -1524,7 +1553,8 @@
         "stance": "1",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -1574,7 +1604,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -1627,7 +1658,8 @@
         "stance": "",
         "charge": "1",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -1692,7 +1724,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": "knockback"
       }
     },
     {
@@ -1733,7 +1766,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -1780,7 +1814,8 @@
         "stance": "1",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -1834,7 +1869,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -1854,7 +1890,7 @@
         "english": "Regroup"
       },
       "tooltip": {
-        "english": "~w~Repositions~/~ to an adjacent tile, replenishes ~w~/*Block_Power*/%~/~ Max Block Power, and reduces the ability tree's cooldowns by ~lg~1~/~ turn for each visible enemy within ~w~3~/~ tiles.##Activates ~lg~\"Regroup\"~/~ for ~w~10~/~ turns:##~lg~+5%~/~ Block Chance#~lg~+5%~/~ Max Block Power#~lg~+15%~/~ Block Power Recovery#~lg~+5%~/~ Counter Chance##Grants an extra stack of the effect (up to ~w~IV~/~) for each ability tree's skill that was on cooldown before its activation."
+        "english": "~w~Repositions~/~ to an adjacent tile, replenishes ~w~/*Block_Power*/%~/~ Max Block Power, and reduces the cooldowns of the ability tree's other skills by ~lg~1~/~ turn for each visible enemy within ~w~3~/~ tiles.##Activates ~lg~\"Regroup\"~/~ for ~w~10~/~ turns:##~lg~+5%~/~ Block Chance#~lg~+5%~/~ Max Block Power#~lg~+15%~/~ Block Power Recovery#~lg~+5%~/~ Counter Chance##Grants an extra stack of the effect (up to ~w~IV~/~) for each reduced cooldown."
       },
       "formulas": {
         "Block_Power": "math_round(2 * Vitality)"
@@ -1884,7 +1920,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -1939,7 +1976,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -1958,7 +1996,7 @@
         "english": "Dexterity"
       },
       "tooltip": {
-        "english": "Killing enemies with melee strikes activates ~lg~\"Taking Aim\"~/~ for ~w~1~/~ turn the next time the character switches to a loadout with an equipped ~w~ranged weapon~/~ (if the weapon is a ~w~crossbow~/~, also instantly reloads it).##If equipped with a ~w~ranged weapon~/~, switching to another loadout doesn't take a turn.##Reduces the chance of bolts and arrows breaking upon hitting their target (from ~r~50%~/~ to ~r~25%~/~)."
+        "english": "Killing enemies with melee strikes activates ~lg~\"Taking Aim\"~/~ for ~w~1~/~ turn the next time the character switches to the loadout with an equipped ~w~ranged weapon~/~ (if the weapon is a ~w~crossbow~/~, also instantly reloads it).##If equipped with a ~w~ranged weapon~/~, switching to the loadout with a ~w~melee weapon~/~ doesn't take a turn.##Reduces the chance of bolts and arrows breaking upon hitting their target (from ~r~50%~/~ to ~r~25%~/~)."
       },
       "is_passive": true
     },
@@ -2001,7 +2039,8 @@
         "stance": "",
         "charge": "1",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -2053,7 +2092,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -2089,7 +2129,8 @@
         "stance": "1",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -2141,7 +2182,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -2188,7 +2230,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -2240,7 +2283,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -2295,7 +2339,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -2351,7 +2396,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -2415,7 +2461,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": "knockback"
       }
     },
     {
@@ -2431,7 +2478,7 @@
       "attributes": {
         "target": "No Target",
         "range": "1",
-        "cooldown": "12",
+        "cooldown": "14",
         "reserv": "0",
         "duration": "10",
         "aoe_length": "0",
@@ -2439,7 +2486,7 @@
         "is_movement": "0",
         "pattern": "normal",
         "validators": "",
-        "energy": "12",
+        "energy": "14",
         "class": "skill",
         "bonus_range": "0",
         "branch": "shield",
@@ -2452,7 +2499,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -2496,7 +2544,7 @@
       "attributes": {
         "target": "Target Object",
         "range": "1",
-        "cooldown": "8",
+        "cooldown": "10",
         "reserv": "0",
         "duration": "0",
         "aoe_length": "0",
@@ -2517,7 +2565,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": "knockback"
       }
     },
     {
@@ -2557,7 +2606,8 @@
         "stance": "",
         "charge": "1",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": "knockback"
       }
     },
     {
@@ -2615,7 +2665,8 @@
         "stance": "1",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -2665,7 +2716,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     }
   ],
@@ -2683,7 +2735,7 @@
       "attributes": {
         "target": "Target Object",
         "range": "1",
-        "cooldown": "10",
+        "cooldown": "12",
         "reserv": "0",
         "duration": "0",
         "aoe_length": "0",
@@ -2704,7 +2756,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -2755,7 +2808,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -2807,7 +2861,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -2844,13 +2899,14 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
       "key": "berserk_traditions",
       "name": {
-        "english": "Berserk Tradition"
+        "english": "Berserker Tradition"
       },
       "tooltip": {
         "english": "Grants:##~lg~-0.3%~/~ Damage Taken for each missing ~r~percent~/~ of Health#~lg~+4%~/~ Crit Chance for ~w~10~/~ turns for each missed or fumbled strike (the effect stacks up to ~w~5~/~ times)#~lg~+1%~/~ Weapon Damage for each percent of Pain#~lg~+10%~/~ Dodge Chance for each degree of ~r~Injury~/~#~lg~+3%~/~ Counter Chance for ~w~10~/~ turns for each received strike (the effect stacks up to ~w~5~/~ times)#~lg~+10%~/~ Crit Efficiency for each adjacent enemy"
@@ -2910,7 +2966,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -2958,7 +3015,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -3004,7 +3062,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -3080,7 +3139,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -3153,7 +3213,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     }
   ],
@@ -3197,7 +3258,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -3259,7 +3321,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -3293,7 +3356,7 @@
       "attributes": {
         "target": "No Target",
         "range": "1",
-        "cooldown": "24",
+        "cooldown": "28",
         "reserv": "0",
         "duration": "1",
         "aoe_length": "0",
@@ -3301,7 +3364,7 @@
         "is_movement": "0",
         "pattern": "normal",
         "validators": "",
-        "energy": "16",
+        "energy": "20",
         "class": "skill",
         "bonus_range": "0",
         "branch": "combat",
@@ -3314,7 +3377,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -3330,7 +3394,7 @@
       "attributes": {
         "target": "No Target",
         "range": "1",
-        "cooldown": "24",
+        "cooldown": "28",
         "reserv": "0",
         "duration": "1",
         "aoe_length": "0",
@@ -3338,7 +3402,7 @@
         "is_movement": "0",
         "pattern": "normal",
         "validators": "",
-        "energy": "16",
+        "energy": "20",
         "class": "skill",
         "bonus_range": "0",
         "branch": "combat",
@@ -3351,7 +3415,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -3385,7 +3450,7 @@
       "attributes": {
         "target": "Target Object",
         "range": "2",
-        "cooldown": "16",
+        "cooldown": "18",
         "reserv": "0",
         "duration": "1",
         "aoe_length": "0",
@@ -3406,7 +3471,8 @@
         "stance": "",
         "charge": "1",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -3447,7 +3513,7 @@
         "is_movement": "0",
         "pattern": "normal",
         "validators": "",
-        "energy": "10",
+        "energy": "12",
         "class": "skill",
         "bonus_range": "0",
         "branch": "combat",
@@ -3460,7 +3526,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -3506,7 +3573,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -3561,7 +3629,7 @@
         "is_movement": "1",
         "pattern": "normal",
         "validators": "",
-        "energy": "10",
+        "energy": "12",
         "class": "skill",
         "bonus_range": "0",
         "branch": "athletic",
@@ -3574,7 +3642,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -3630,7 +3699,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": "knockback"
       }
     },
     {
@@ -3667,7 +3737,8 @@
         "stance": "",
         "charge": "1",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -3699,7 +3770,7 @@
       "attributes": {
         "target": "Target Object",
         "range": "1",
-        "cooldown": "12",
+        "cooldown": "14",
         "reserv": "0",
         "duration": "1",
         "aoe_length": "0",
@@ -3707,7 +3778,7 @@
         "is_movement": "0",
         "pattern": "normal",
         "validators": "",
-        "energy": "14",
+        "energy": "20",
         "class": "skill",
         "bonus_range": "0",
         "branch": "athletic",
@@ -3720,7 +3791,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -3774,7 +3846,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -3835,7 +3908,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -3872,7 +3946,7 @@
         "is_movement": "0",
         "pattern": "normal",
         "validators": "",
-        "energy": "20",
+        "energy": "18",
         "class": "spell",
         "bonus_range": "0",
         "branch": "magic_mastery",
@@ -3885,7 +3959,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": ""
       }
     },
     {
@@ -3947,7 +4022,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": ""
       }
     },
     {
@@ -3963,7 +4039,7 @@
       "attributes": {
         "target": "No Target",
         "range": "0",
-        "cooldown": "8",
+        "cooldown": "12",
         "reserv": "0",
         "duration": "0",
         "aoe_length": "0",
@@ -3971,7 +4047,7 @@
         "is_movement": "0",
         "pattern": "normal",
         "validators": "",
-        "energy": "12",
+        "energy": "20",
         "class": "spell",
         "bonus_range": "0",
         "branch": "magic_mastery",
@@ -3984,7 +4060,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": ""
       }
     },
     {
@@ -4022,7 +4099,7 @@
         "is_movement": "0",
         "pattern": "normal",
         "validators": "",
-        "energy": "20",
+        "energy": "24",
         "class": "spell",
         "bonus_range": "1",
         "branch": "magic_mastery",
@@ -4035,7 +4112,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": ""
       }
     },
     {
@@ -4075,7 +4153,7 @@
       "attributes": {
         "target": "Target Object",
         "range": "6",
-        "cooldown": "40",
+        "cooldown": "36",
         "reserv": "0",
         "duration": "0",
         "aoe_length": "0",
@@ -4083,7 +4161,7 @@
         "is_movement": "0",
         "pattern": "normal",
         "validators": "",
-        "energy": "40",
+        "energy": "42",
         "class": "spell",
         "bonus_range": "1",
         "branch": "magic_mastery",
@@ -4096,7 +4174,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": ""
       }
     },
     {
@@ -4135,7 +4214,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": ""
       }
     },
     {
@@ -4200,7 +4280,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -4251,7 +4332,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -4298,7 +4380,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "1",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -4341,7 +4424,8 @@
         "stance": "",
         "charge": "1",
         "maneuver": "",
-        "spell": ""
+        "spell": "",
+        "tags": ""
       }
     },
     {
@@ -4394,7 +4478,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "offensive"
       }
     },
     {
@@ -4455,7 +4540,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "offensive"
       }
     },
     {
@@ -4504,7 +4590,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "offensive"
       }
     },
     {
@@ -4546,7 +4633,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "offensive"
       }
     },
     {
@@ -4596,7 +4684,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "offensive"
       }
     },
     {
@@ -4647,7 +4736,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "offensive"
       }
     },
     {
@@ -4696,7 +4786,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "offensive"
       }
     },
     {
@@ -4749,7 +4840,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "knockback, offensive"
       }
     },
     {
@@ -4791,7 +4883,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": ""
       }
     },
     {
@@ -4842,7 +4935,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "knockback, offensive"
       }
     },
     {
@@ -4904,7 +4998,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "offensive"
       }
     },
     {
@@ -4964,7 +5059,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "offensive"
       }
     },
     {
@@ -5016,7 +5112,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "knockback, offensive"
       }
     },
     {
@@ -5058,7 +5155,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "knockback, offensive"
       }
     },
     {
@@ -5112,7 +5210,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "knockback, offensive"
       }
     },
     {
@@ -5156,7 +5255,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "knockback, offensive"
       }
     },
     {
@@ -5209,7 +5309,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "offensive"
       }
     },
     {
@@ -5249,7 +5350,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "offensive"
       }
     },
     {
@@ -5282,7 +5384,7 @@
       "attributes": {
         "target": "Target Object",
         "range": "6",
-        "cooldown": "20",
+        "cooldown": "22",
         "reserv": "0",
         "duration": "0",
         "aoe_length": "0",
@@ -5303,7 +5405,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "offensive"
       }
     },
     {
@@ -5343,7 +5446,7 @@
       "attributes": {
         "target": "Target Point",
         "range": "4",
-        "cooldown": "24",
+        "cooldown": "26",
         "reserv": "0",
         "duration": "0",
         "aoe_length": "0",
@@ -5364,7 +5467,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "offensive"
       }
     },
     {
@@ -5383,7 +5487,7 @@
         "english": "Resonance Cascade"
       },
       "tooltip": {
-        "english": "Each ~w~third~/~ use of the ability tree's spells with ~w~/*Debuff_Chance*/%~/~ chance applies ~r~\"Resonance\"~/~ for ~w~3~/~ turns to a random target within Vision without this effect.##If there are no such targets, prolongs the duration of ~r~\"Resonance\"~/~ or ~r~\"Impulse\"~/~ affecting a random ~ly~Resonating~/~ target within Vision by ~w~3~/~ turns."
+        "english": "Each ~w~third~/~ use of the ability tree's spells with ~w~/*Debuff_Chance*/%~/~ chance applies ~r~\"Resonance\"~/~ for ~w~3~/~ turns to a random enemy within Vision without this effect.##If there are no such enemies, prolongs the duration of ~r~\"Resonance\"~/~ or ~r~\"Impulse\"~/~ affecting a random ~ly~Resonating~/~ target within Vision by ~w~3~/~ turns."
       },
       "formulas": {
         "Debuff_Chance": "math_round(75 * ((Magic_Power + Electromantic_Power) / 100))"
@@ -5429,7 +5533,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "offensive"
       }
     },
     {
@@ -5454,14 +5559,14 @@
         "english": "Applies the target with ~r~\"Wormhole\"~/~ for ~w~3~/~ turns and marks its tile.##When the effect expires or is removed, ~w~teleports~/~ the target to the marked tile, dealing ~p~/*Arcane_Damage*/ Arcane Damage~/~.##If the marked tile is occupied, ~w~teleports~/~ the target to the closest empty tile, dealing additional ~p~/*Arcane_Damage_Add*/ Arcane Damage~/~ and with ~w~/*Stun_Chance*/%~/~ chance ~w~Stunning~/~ it.##While ~r~\"Wormhole\"~/~ is active, the spell doesn't go on cooldown and can be used again without spending Energy to remove the effect from the target.##The spell can't be used on giant or stationary targets and doesn't harm the caster."
       },
       "formulas": {
-        "Arcane_Damage": "(5 * (1 + Arcanistic_Power / 100) * Magic_Power / 100)",
-        "Arcane_Damage_Add": "(11 * (1 + Arcanistic_Power / 100) * Magic_Power / 100)",
+        "Arcane_Damage": "(8 * (1 + Arcanistic_Power / 100) * Magic_Power / 100)",
+        "Arcane_Damage_Add": "(12 * (1 + Arcanistic_Power / 100) * Magic_Power / 100)",
         "Stun_Chance": "(60 * ((Magic_Power + Arcanistic_Power) / 100))"
       },
       "is_passive": false,
       "attributes": {
         "target": "Target Object",
-        "range": "4",
+        "range": "5",
         "cooldown": "8",
         "reserv": "0",
         "duration": "0",
@@ -5472,7 +5577,7 @@
         "validators": "",
         "energy": "16",
         "class": "spell",
-        "bonus_range": "1",
+        "bonus_range": "0",
         "branch": "arcanistics",
         "is_knockback": "0",
         "crime": "1",
@@ -5483,7 +5588,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": ""
       }
     },
     {
@@ -5492,10 +5598,11 @@
         "english": "Dimensional Shift"
       },
       "tooltip": {
-        "english": "Marks two targets, then ~w~teleports~/~ them, swapping their positions.##Deals ~p~/*Arcane_Damage*/ Arcane Damage~/~ to both targets for each tile of distance between them, and with ~w~/*Debuff_Chance*/%~/~ chance ~w~Confuses~/~ them for ~w~3~/~ turns or ~w~Dazes~/~ for ~w~2~/~ turns.##Applies both targets with ~r~/*Weapon_Damage*/%~/~ Weapon Damage, ~r~/*Hit_Chance*/%~/~ Accuracy, and ~r~/*FMB*/%~/~ Fumble Chance for ~w~3~/~ turns.##The effect stacks up to ~w~2~/~ times.##The spell can't be used on giant or stationary targets, doesn't harm the caster, and doesn't apply penalties to their allies."
+        "english": "Marks two targets, then ~w~teleports~/~ them, swapping their positions and dealing ~p~/*Arcane_Damage_Base*/ Arcane Damage~/~.##Also deals ~p~/*Arcane_Damage*/ Arcane Damage~/~ to both targets for each tile of distance between them, and with ~w~/*Debuff_Chance*/%~/~ chance ~w~Confuses~/~ them for ~w~3~/~ turns or ~w~Dazes~/~ for ~w~2~/~ turns.##Applies both targets with ~r~/*Weapon_Damage*/%~/~ Weapon Damage, ~r~/*Hit_Chance*/%~/~ Accuracy, and ~r~/*FMB*/%~/~ Fumble Chance for ~w~3~/~ turns.##The effect stacks up to ~w~2~/~ times.##The spell can't be used on giant or stationary targets, doesn't harm the caster, and doesn't apply penalties to their allies."
       },
       "formulas": {
-        "Arcane_Damage": "(2 * (1 + Arcanistic_Power / 100) * Magic_Power / 100)",
+        "Arcane_Damage": "(1 * (1 + Arcanistic_Power / 100) * Magic_Power / 100)",
+        "Arcane_Damage_Base": "(5 * (1 + Arcanistic_Power / 100) * Magic_Power / 100)",
         "Debuff_Chance": "(80 * ((Magic_Power + Arcanistic_Power) / 100))",
         "Weapon_Damage": "(-0.5 * WIL)",
         "Hit_Chance": "(-0.5 * WIL)",
@@ -5505,7 +5612,7 @@
       "attributes": {
         "target": "Target Object",
         "range": "5",
-        "cooldown": "6",
+        "cooldown": "8",
         "reserv": "0",
         "duration": "0",
         "aoe_length": "0",
@@ -5513,7 +5620,7 @@
         "is_movement": "0",
         "pattern": "normal",
         "validators": "",
-        "energy": "12",
+        "energy": "10",
         "class": "spell",
         "bonus_range": "1",
         "branch": "arcanistics",
@@ -5526,7 +5633,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": ""
       }
     },
     {
@@ -5535,7 +5643,7 @@
         "english": "Arcane Might"
       },
       "tooltip": {
-        "english": "Dealing ~p~Arcane Damage~/~ with strikes, shots, and spells grants ~lg~+2%~/~ Accuracy, ~lg~-2%~/~ Fumble Chance, ~lg~-2%~/~ Backfire Chance, ~lg~+2%~/~ Crit Chance, and ~lg~+2%~/~ Miracle Chance for ~w~4~/~ turns.##The effect stacks up to ~w~3~/~ times.##~w~Teleporting~/~ grants ~lg~+1~/~ Range to ~w~Arcanistics~/~ spells for ~w~4~/~ turns and ~lg~-15%~/~ Backfire Damage Change for ~w~2~/~ turns."
+        "english": "Dealing ~p~Arcane Damage~/~ with strikes, shots, and spells grants ~lg~+2%~/~ Accuracy, ~lg~-2%~/~ Fumble Chance, ~lg~-2%~/~ Backfire Chance, ~lg~+2%~/~ Crit Chance, and ~lg~+2%~/~ Miracle Chance for ~w~4~/~ turns.##The effect stacks up to ~w~3~/~ times.##~w~Teleporting~/~ grants ~lg~+1~/~ Range to ~w~Arcanistics~/~ spells and ~lg~-5%~/~ Backfire Damage Change for ~w~4~/~ turns."
       },
       "is_passive": true
     },
@@ -5545,7 +5653,7 @@
         "english": "Time Echo"
       },
       "tooltip": {
-        "english": "When ~r~\"Wormhole\"~/~ expires or is removed after being applied to the character, replenishes ~w~33%~/~ Health and Energy lost over the course of the effect.##When ~r~\"Wormhole\"~/~ expires or is removed after being applied to an enemy, deals additional ~p~Arcane Damage~/~ equal to ~w~33%~/~ of the damage they received over the course of the effect."
+        "english": "When ~r~\"Wormhole\"~/~ expires or is removed after being applied to the character, replenishes ~w~50%~/~ Health and Energy lost over the course of the effect.##When ~r~\"Wormhole\"~/~ expires or is removed after being applied to an enemy, deals additional ~p~Arcane Damage~/~ equal to ~w~33%~/~ of the damage they received over the course of the effect."
       },
       "is_passive": true
     },
@@ -5558,7 +5666,7 @@
         "english": "Deals ~p~/*Arcane_Damage*/ Arcane Damage~/~ to a ~w~5x5~/~ tile area (except the central tile) and with ~w~/*Debuff_Chance*/%~/~ chance ~w~Staggers~/~ or ~w~Immobilizes~/~ all affected targets.##With ~w~/*Knockback_Chance*/%~/~ chance ~w~knocks~/~ back the targets adjacent to the area's center and ~w~pulls~/~ the targets that are ~w~1~/~ tile away from it.##The spell doesn't harm the caster, aside from ~p~Arcane Damage~/~."
       },
       "formulas": {
-        "Arcane_Damage": "(10 * (1 + Arcanistic_Power / 100) * Magic_Power / 100)",
+        "Arcane_Damage": "(11 * (1 + Arcanistic_Power / 100) * Magic_Power / 100)",
         "Debuff_Chance": "(40 * ((Magic_Power + Arcanistic_Power) / 100))",
         "Knockback_Chance": "(100 * ((Magic_Power + Arcanistic_Power) / 100))"
       },
@@ -5587,7 +5695,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "knockback"
       }
     },
     {
@@ -5609,7 +5718,7 @@
         "english": "Aether Shield"
       },
       "tooltip": {
-        "english": "Activates ~lg~\"Aether Shield\"~/~ for ~w~3~/~ turns:##~lg~/*Control_Res*/%~/~ Control Resistance#~lg~/*Move_Res*/%~/~ Move Resistance#~lg~/*Bleed_Res*/%~/~ Bleed Resistance#~lg~/*Damage_Taken*/%~/~ Damage Taken#Replenishes Energy for ~w~33%~/~ of the damage received.#~w~Destroys~/~ all physical and magical projectiles (including thrown items) that would hit the caster, preventing their damage and effects.#~w~Colliding~/~ with targets deals additional ~p~Arcane Damage~/~ to them.##While affected by ~lg~\"Aether Shield\"~/~, ~w~teleporting~/~ prolongs the effect's duration by ~lg~3~/~ turns (up to ~w~6~/~), and grants all strikes and shots ~p~/*Arcane_Damage*/ Arcane Damage~/~ for ~w~4~/~ turns.##The effect stacks up to ~w~2~/~ times."
+        "english": "Activates ~lg~\"Aether Shield\"~/~ for ~w~2~/~ turns (~w~+1~/~ turn for each other learned ~w~Arcanistics~/~ spell):##~lg~/*Control_Res*/%~/~ Control Resistance#~lg~/*Move_Res*/%~/~ Move Resistance#~lg~/*Bleed_Res*/%~/~ Bleed Resistance#~lg~/*Damage_Taken*/%~/~ Damage Taken#Replenishes Energy for ~w~20%~/~ of the damage received.#~w~Destroys~/~ all physical and magical projectiles (including thrown items) that would hit the caster, preventing their damage and effects.##~w~Teleporting~/~ prolongs the effect's duration by ~lg~3~/~ turns (up to ~w~8~/~), and each destroyed projectile reduces it by ~w~1~/~ turn.##While affected by ~lg~\"Aether Shield\"~/~, ~w~teleporting~/~ also grants all strikes and shots ~p~/*Arcane_Damage*/ Arcane Damage~/~ for ~w~4~/~ turns.##The effect stacks up to ~w~2~/~ times."
       },
       "formulas": {
         "Arcane_Damage": "(0.1 * WIL * (1 + Arcanistic_Power / 100) * Magic_Power / 100)",
@@ -5643,7 +5752,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": ""
       }
     },
     {
@@ -5655,7 +5765,7 @@
         "english": "If ~w~\"Schism\"~/~ (or ~w~\"Arcane Tether\"~/~ of the summoned ~w~Phantasm~/~) successfully ~w~knocks~/~ back or ~w~pulls~/~ the target, applies it with ~r~-10%~/~ Magic Resistance and ~r~-10%~/~ Arcane Resistance for ~w~3~/~ turns.##The effect stacks up to ~w~2~/~ times.##If these spells fail to ~w~knock~/~ back or ~w~pull~/~ the target, deals ~p~/*Arcane_Damage*/ Arcane Damage~/~ to it instead."
       },
       "formulas": {
-        "Arcane_Damage": "(5 * (1 + Arcanistic_Power / 100))"
+        "Arcane_Damage": "(4 * (1 + Arcanistic_Power / 100))"
       },
       "is_passive": true
     },
@@ -5665,21 +5775,21 @@
         "english": "Mana Crystal"
       },
       "tooltip": {
-        "english": "Summons a ~w~Mana Crystal~/~ on the targeted tile, which persists for ~w~8~/~ turns.##Each turn, the ~w~Crystal~/~ shoots a bolt of Aether at the enemy with the lowest Health within ~w~/*Range*/~/~ tiles, dealing ~p~/*Arcane_Damage*/ Arcane Damage~/~ with ~w~/*Hit_Chance*/%~/~ Accuracy, ~w~/*Armor_Piercing*/%~/~ Armor Penetration, ~w~/*CRT*/%~/~ Crit Chance, and ~w~/*CRTD*/%~/~ Crit Efficiency.##The offensive capabilities and Max Health of the ~w~Crystal~/~ change dynamically depending on the caster's stats.#The ~w~Crystal~/~ doesn't move and is immune to all effects (except ~r~\"Stasis\"~/~ and ~r~\"Wormhole\"~/~).##When ~w~teleported~/~, the ~w~Crystal~/~ shoots ~w~3~/~ bolts at random enemies within ~w~/*Range*/~/~ tiles, distributing them evenly."
+        "english": "Summons a ~w~Mana Crystal~/~ on the targeted tile, which persists for ~w~8~/~ turns.##Each turn, the ~w~Crystal~/~ shoots a bolt of Aether at the enemy with the lowest Health within ~w~/*Range*/~/~ tiles, dealing ~p~/*Arcane_Damage*/ Arcane Damage~/~ with ~w~/*Hit_Chance*/%~/~ Accuracy, ~w~/*Armor_Piercing*/%~/~ Armor Penetration, ~w~/*CRT*/%~/~ Crit Chance, and ~w~/*CRTD*/%~/~ Crit Efficiency.##The offensive capabilities and Max Health of the ~w~Crystal~/~ change dynamically depending on the caster's stats, reducing with distance to the caster.#The ~w~Crystal~/~ doesn't move and is immune to all effects (except ~r~\"Stasis\"~/~ and ~r~\"Wormhole\"~/~).##When ~w~teleported~/~, the ~w~Crystal~/~ shoots ~w~3~/~ bolts at random enemies within ~w~/*Range*/~/~ tiles, distributing them evenly."
       },
       "formulas": {
         "Range": "4",
         "Arcane_Damage": "((1 + Arcanistic_Power / 100) * 10)",
-        "Hit_Chance": "((-Miscast_Chance) + 100)",
-        "CRT": "(Miracle_Chance + 3)",
-        "CRTD": "(Miracle_Power + 100)",
+        "Hit_Chance": "(75 - Miscast_Chance + 100)",
+        "CRT": "(0.5 * Miracle_Chance + 3)",
+        "CRTD": "(0.5 * Miracle_Power + 100)",
         "Armor_Piercing": "(PRC - 10 + 10)"
       },
       "is_passive": false,
       "attributes": {
         "target": "Target Point",
         "range": "3",
-        "cooldown": "20",
+        "cooldown": "24",
         "reserv": "0",
         "duration": "0",
         "aoe_length": "0",
@@ -5687,7 +5797,7 @@
         "is_movement": "0",
         "pattern": "normal",
         "validators": "",
-        "energy": "32",
+        "energy": "34",
         "class": "spell",
         "bonus_range": "1",
         "branch": "arcanistics",
@@ -5700,7 +5810,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "offensive"
       }
     },
     {
@@ -5740,7 +5851,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": ""
       }
     },
     {
@@ -5749,20 +5861,20 @@
         "english": "Phantasm"
       },
       "tooltip": {
-        "english": "Summons a ~w~Phantasm~/~ on the targeted tile, which persists for ~w~8~/~ turns.##Each turn, the ~w~Phantasm~/~ deals ~p~/*Arcane_Damage*/ Arcane Damage~/~ to a random adjacent enemy with ~w~/*Hit_Chance*/%~/~ Accuracy, ~w~/*Armor_Piercing*/%~/~ Armor Penetration, ~w~/*CRT*/%~/~ Crit Chance, and ~w~/*CRTD*/%~/~ Crit Efficiency.##The offensive capabilities and Max Health of the ~w~Phantasm~/~ change dynamically depending on the caster's stats.#The ~w~Phantasm~/~ can move within ~w~2~/~ tiles of its summoning or ~w~teleportation~/~ spot, is immune to all effects (except ~r~\"Stasis\"~/~ and ~r~\"Wormhole\"~/~), and replenishes Health upon taking ~p~Arcane Damage~/~.##The ~w~Phantasm~/~ has access to the following abilities: ~w~\"Arcane Tether\"~/~, which ~w~pulls~/~ enemies in, ~w~\"Mana Siphon\"~/~, which steals Energy, and ~w~\"Consonance\"~/~, which prolongs its summoning duration.##~w~Teleporting~/~ the ~w~Phantasm~/~ instantly refreshes all its cooldowns."
+        "english": "Summons a ~w~Phantasm~/~ on the targeted tile, which persists for ~w~8~/~ turns.##Each turn, the ~w~Phantasm~/~ deals ~p~/*Arcane_Damage*/ Arcane Damage~/~ to a random adjacent enemy with ~w~/*Hit_Chance*/%~/~ Accuracy, ~w~/*Armor_Piercing*/%~/~ Armor Penetration, ~w~/*CRT*/%~/~ Crit Chance, and ~w~/*CRTD*/%~/~ Crit Efficiency.##The offensive capabilities and Max Health of the ~w~Phantasm~/~ change dynamically depending on the caster's stats, reducing with distance to the caster.#The ~w~Phantasm~/~ can move within ~w~2~/~ tiles of its summoning or ~w~teleportation~/~ spot, is immune to all effects (except ~r~\"Stasis\"~/~ and ~r~\"Wormhole\"~/~), and replenishes Health upon taking ~p~Arcane Damage~/~.##The ~w~Phantasm~/~ has access to the following abilities: ~w~\"Arcane Tether\"~/~, which ~w~pulls~/~ enemies in, ~w~\"Mana Siphon\"~/~, which steals Energy, and ~w~\"Consonance\"~/~, which prolongs its summoning duration.##~w~Teleporting~/~ the ~w~Phantasm~/~ instantly refreshes all its cooldowns."
       },
       "formulas": {
         "Arcane_Damage": "((1 + Arcanistic_Power / 100) * 26)",
         "Hit_Chance": "((-Miscast_Chance) + 110)",
-        "CRT": "(Miracle_Chance + 12)",
-        "CRTD": "(Miracle_Power + 120)",
-        "Armor_Piercing": "(2 * PRC - 20 + 10)"
+        "CRT": "(0.5 * Miracle_Chance + 12)",
+        "CRTD": "(0.5 * Miracle_Power + 120)",
+        "Armor_Piercing": "(PRC - 10 + 10)"
       },
       "is_passive": false,
       "attributes": {
         "target": "Target Point",
-        "range": "2",
-        "cooldown": "24",
+        "range": "3",
+        "cooldown": "36",
         "reserv": "0",
         "duration": "0",
         "aoe_length": "0",
@@ -5770,7 +5882,7 @@
         "is_movement": "0",
         "pattern": "normal",
         "validators": "",
-        "energy": "44",
+        "energy": "56",
         "class": "spell",
         "bonus_range": "1",
         "branch": "arcanistics",
@@ -5783,7 +5895,8 @@
         "stance": "",
         "charge": "",
         "maneuver": "",
-        "spell": "1"
+        "spell": "1",
+        "tags": "offensive"
       }
     },
     {
@@ -5802,7 +5915,7 @@
         "english": "Aether Harmony"
       },
       "tooltip": {
-        "english": "Once per ~w~10~/~ turns, producing a miracle with ~w~\"Mana Crystal\"~/~ instantly refreshes the spell's cooldown and grants it ~lg~-30%~/~ Energy Cost during the next use.##Each entity currently summoned with ~w~Arcanistics~/~ grants ~lg~-5%~/~ Backfire Damage Change and ~lg~+10%~/~ Magic Power."
+        "english": "Once per ~w~10~/~ turns, producing a miracle with ~w~\"Mana Crystal\"~/~ instantly refreshes the spell's cooldown and grants it ~lg~-20%~/~ Energy Cost during the next use.##Each entity currently summoned with ~w~Arcanistics~/~ grants ~lg~-5%~/~ Backfire Damage Change and ~lg~+10%~/~ Magic Power."
       },
       "is_passive": true
     },

--- a/umt-exporter/ExtractStoneshardTooltipsAndFormulas.csx
+++ b/umt-exporter/ExtractStoneshardTooltipsAndFormulas.csx
@@ -118,6 +118,9 @@ public class SkillAttributes
 
     [JsonPropertyName("spell")]
     public string Spell { get; set; }
+
+    [JsonPropertyName("tags")]
+    public string Tags { get; set; }
 }
 
 public class LocalizedText
@@ -263,7 +266,7 @@ await Task.Run(() => {
                 if (str.Content.ToLower().StartsWith(currentKey))
                 {
                     string[] subs = str.Content.Split(";");
-                    if (subs.Length == 28)
+                    if (subs.Length == 29)
                     {
                         var attributes = new SkillAttributes();
                         attributes.Target = subs[2];
@@ -290,6 +293,7 @@ await Task.Run(() => {
                         attributes.Charge = subs[24];
                         attributes.Maneuver = subs[25];
                         attributes.Spell = subs[26];
+                        attributes.Tags = subs[27];
                         skill.Attributes = attributes;
                     }
                     // Translated tooltip or name. Tooltip comes first.


### PR DESCRIPTION
Syncs the talent calculator’s in-app ability tooltips, formulas and attributes with the latest Stoneshard game data.  
Most changes are applied in `index.html`, sourced from the updated extracted `tooltips/stoneshard-tooltips-and-formulas.json`.

### What changed

- Updated multiple abilities’ **Energy/Cooldown** values to match the latest in-game data (notably several **Arcanistics** adjustments).
- Updated ability tooltips and formulas in `index.html` to match current in-game values.
- Updated extracted source data: `tooltips/stoneshard-tooltips-and-formulas.json`.
- Updated the UMT extractor to capture the new upstream `tags` field (stored in JSON only for now).
