### PR TITLE
Make level down clear current level allocations

### DIFF
--- a/calculator/build-ledger.js
+++ b/calculator/build-ledger.js
@@ -83,6 +83,15 @@ export default class BuildLedger {
   }
 
   /**
+   * Returns the number of allocations (abilities + stats) in the current level entry.
+   *
+   * @returns {number}
+   */
+  get currentLevelAllocationCount() {
+    return this.#levels[this.level].allocations.length;
+  }
+
+  /**
    * Advances the character by one level.
    *
    * Ability and stat points are derived from the character's level:
@@ -112,6 +121,25 @@ export default class BuildLedger {
 
     this.#levels.pop();
     return { ok: true };
+  }
+
+  /**
+   * Clears the current level's allocations. If level > 1, also levels down by discarding the current level entry.
+   *
+   * @returns {{ ok: true, removed: number, leveledDown: boolean }}
+   */
+  clearCurrentLevelAndMaybeLevelDown() {
+    const currentLevel = this.level;
+    const levelEntry = this.#levels[currentLevel];
+    const removed = levelEntry.allocations.length;
+
+    if (currentLevel === 1) {
+      levelEntry.allocations.length = 0;
+      return { ok: true, removed: removed, leveledDown: false };
+    }
+
+    this.#levels.pop();
+    return { ok: true, removed: removed, leveledDown: true };
   }
 
   /**

--- a/calculator/build-ledger.test.js
+++ b/calculator/build-ledger.test.js
@@ -114,3 +114,34 @@ test('refundAbilities removes multiple abilities', () => {
 
   assert.deepEqual(ledger.refundAbilities(['swords-1']), { ok: false, reason: 'none-found' });
 });
+
+test('clearCurrentLevelAndMaybeLevelDown clears allocations and levels down when possible', () => {
+  const ledger = new BuildLedger();
+
+  assert.deepEqual(ledger.addAbility('swords-1'), { ok: true });
+  assert.deepEqual(ledger.addAbility('swords-2'), { ok: true });
+
+  ledger.levelUp();
+  assert.deepEqual(ledger.addAbility('swords-3'), { ok: true });
+
+  ledger.levelUp();
+  assert.deepEqual(ledger.addAbility('swords-4'), { ok: true });
+
+  assert.equal(ledger.level, 3);
+
+  assert.deepEqual(ledger.clearCurrentLevelAndMaybeLevelDown(), {
+    ok: true,
+    removed: 1,
+    leveledDown: true,
+  });
+  assert.deepEqual(ledger.clearCurrentLevelAndMaybeLevelDown(), {
+    ok: true,
+    removed: 1,
+    leveledDown: true,
+  });
+  assert.deepEqual(ledger.clearCurrentLevelAndMaybeLevelDown(), {
+    ok: true,
+    removed: 2,
+    leveledDown: false,
+  });
+});

--- a/talent-calculator.js
+++ b/talent-calculator.js
@@ -241,6 +241,8 @@ class TalentCalculator extends HTMLElement {
     );
 
     this.#levelDisplay = this.querySelector('#level-output');
+    this.#levelIncButton = this.querySelector('button[data-scope="level"][data-action="inc"]');
+    this.#levelDecButton = this.querySelector('button[data-scope="level"][data-action="dec"]');
     this.#updateLevelDisplay();
 
     this.#statPointsDisplay = this.querySelector('#stat-points-display');
@@ -255,9 +257,6 @@ class TalentCalculator extends HTMLElement {
     this.#vitDisplay = this.querySelector('#vit-display');
     this.#wilDisplay = this.querySelector('#wil-display');
     this.#updateStatsDisplay();
-
-    this.#levelIncButton = this.querySelector('button[data-scope="level"][data-action="inc"]');
-    this.#levelDecButton = this.querySelector('button[data-scope="level"][data-action="dec"]');
 
     if (!this.#onAdjustClickBound) {
       this.#onAdjustClickBound = this.#onAdjustClick.bind(this);
@@ -318,8 +317,10 @@ class TalentCalculator extends HTMLElement {
   }
 
   #requestLevelDown() {
-    const res = this.#ledger.levelDown();
+    const res = this.#ledger.clearCurrentLevelAndMaybeLevelDown();
     if (!res.ok) return;
+    this.#syncAbilityPicksFromLedger();
+    this.#recomputeCharacterFromLedger();
     this.#refreshAfterLedgerChange();
   }
 
@@ -385,7 +386,8 @@ class TalentCalculator extends HTMLElement {
     }
 
     if (this.#levelDecButton) {
-      this.#levelDecButton.disabled = !this.#ledger.canLevelDown();
+      this.#levelDecButton.disabled =
+        this.#ledger.level === 1 && this.#ledger.currentLevelAllocationCount === 0;
     }
   }
 


### PR DESCRIPTION
## Summary
Level down now clears allocations in the current level.  
If the build is above level 1, it also decreases the level.  
At level 1, it only clears allocations and keeps the level unchanged.

The level-down button is disabled only when level 1 has no allocations.
