### PR TITLE
Fix missing child links in ability trees

### DIFF
--- a/index.html
+++ b/index.html
@@ -1648,7 +1648,7 @@
         </ability-pick>
         <ability-pick
           id="two-handed_swords-7"
-          children="two-handed_swords-10"
+          children="two-handed_swords-9 two-handed_swords-10"
           parents="two-handed_swords-3"
           style="top: 231px; left: 251px"
           img="img/abilities/two-handed_swords/Fight_to_the_Death.png"
@@ -8018,7 +8018,7 @@
         </ability-pick>
         <ability-pick
           id="arcanistics-2"
-          children="arcanistics-5 arcanistics-6"
+          children="arcanistics-5 arcanistics-6 arcanistics-7"
           style="top: 85px; left: 137px"
           img="img/abilities/arcanistics/Dimensional_Shift.png"
           label="Dimensional Shift"


### PR DESCRIPTION
## Summary

Fix two missing `children` links in `index.html` so refund propagation can follow the tree graph correctly.

## Changes

- add `arcanistics-7` (`Aether Shield`) as a child of `arcanistics-2` (`Dimensional Shift`)
- add `two-handed_swords-9` (`Heroic Charge`) as a child of `two-handed_swords-7` (`Fight to the Death`)

## Why

The current refund flow follows `children` links in the tree. In these two cases, the relationship was only defined on the child ability through `parents`, so the reverse `children` link was missing.

This should address the Arcanistics case reported in #230 where refunding `Dimensional Shift` did not also refund `Aether Shield`.

## Notes

This is a partial fix related to #230. The Armored Combat behavior described there still needs separate investigation.
