### PR TITLE
Fix incorrect Arcanistics unlock requirements

### DIFF
--- a/index.html
+++ b/index.html
@@ -8077,7 +8077,7 @@
         </ability-pick>
         <ability-pick
           id="arcanistics-3"
-          children="arcanistics-6 arcanistics-7"
+          children="arcanistics-7"
           style="top: 85px; left: 251px"
           img="img/abilities/arcanistics/Arcane_Might.png"
           label="Arcane Might"
@@ -8180,7 +8180,7 @@
         <ability-pick
           id="arcanistics-6"
           children="arcanistics-9 arcanistics-10"
-          parents="arcanistics-2|arcanistics-3"
+          parents="arcanistics-2"
           style="top: 197px; left: 175px"
           img="img/abilities/arcanistics/Transcendental_Anchoring.png"
           label="Transcendental Anchoring"
@@ -8467,7 +8467,7 @@
         </ability-pick>
         <ability-pick
           id="arcanistics-12"
-          parents="arcanistics-8|arcanistics-9"
+          parents="arcanistics-8 arcanistics-9"
           style="top: 421px; left: 99px"
           img="img/abilities/arcanistics/Entropy_Flare.png"
           label="Entropy Flare"


### PR DESCRIPTION
## Summary

Fix two incorrect unlock relationships in the Arcanistics tree to match the game.

## What Was Wrong

- `Transcendental Anchoring` could be unlocked after learning `Arcane Might`, but in the game it only unlocks from `Dimensional Shift`.
- `Entropy Flare` could be unlocked after learning either `Astral Tides` or `Mana Crystal`, but in the game it requires both.

## Changes

- Changed `Transcendental Anchoring` to depend only on `Dimensional Shift`
- Changed `Entropy Flare` to depend on both `Astral Tides` and `Mana Crystal`

## Verification

These relationships were checked against the in-game tree by verifying which connector lines activate and which abilities become available after each pick.

## Notes

This updates tree data only. No refund code changed, but refunds now reflect the corrected Arcanistics relationships.
