### PR TITLE
Recompute main stats so formulas update on stat change

### DIFF
--- a/calculator/character.js
+++ b/calculator/character.js
@@ -10,17 +10,29 @@ export default class Character {
   #race = '';
   #gender = '';
   #uniqueTrait = '';
+  /** @type {Record<StatKey, number>} */
+  #baseStats = {
+    [STATS.STR]: 10,
+    [STATS.AGI]: 10,
+    [STATS.PER]: 10,
+    [STATS.VIT]: 10,
+    [STATS.WIL]: 10,
+  };
 
   constructor(name = '', title = '', race = '', gender = '') {
     this.#name = name;
     this.#title = title;
     this.#race = race;
     this.#gender = gender;
-    this.strength = 10;
-    this.agility = 10;
-    this.perception = 10;
-    this.vitality = 10;
-    this.willpower = 10;
+    this.resetComputedStats();
+  }
+
+  resetComputedStats() {
+    this.strength = this.#baseStats[STATS.STR];
+    this.agility = this.#baseStats[STATS.AGI];
+    this.perception = this.#baseStats[STATS.PER];
+    this.vitality = this.#baseStats[STATS.VIT];
+    this.willpower = this.#baseStats[STATS.WIL];
     this.legsDef = 0;
     this.knockbackChance = 0;
     this.shieldBlockChance = 0;
@@ -67,6 +79,19 @@ export default class Character {
    * @returns {number}
    */
   getBaseStat(stat) {
+    const value = this.#baseStats[stat];
+    if (value != null) return value;
+
+    throw new Error(`Unknown stat: ${stat}`);
+  }
+
+  /**
+   * Returns the current computed value of a stat.
+   *
+   * @param {StatKey} stat
+   * @returns {number}
+   */
+  getEffectiveStat(stat) {
     if (stat === STATS.STR) return this.strength;
     if (stat === STATS.AGI) return this.agility;
     if (stat === STATS.PER) return this.perception;
@@ -74,5 +99,19 @@ export default class Character {
     if (stat === STATS.WIL) return this.willpower;
 
     throw new Error(`Unknown stat: ${stat}`);
+  }
+
+  /**
+   * Applies one ledger-allocated stat increase.
+   *
+   * @param {StatKey} stat
+   */
+  applyStatIncrease(stat) {
+    if (stat === STATS.STR) this.strength++;
+    else if (stat === STATS.AGI) this.agility++;
+    else if (stat === STATS.PER) this.perception++;
+    else if (stat === STATS.VIT) this.vitality++;
+    else if (stat === STATS.WIL) this.willpower++;
+    else throw new Error(`Unknown stat: ${stat}`);
   }
 }

--- a/calculator/character.test.js
+++ b/calculator/character.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import Character from './character.js';
+import { STATS } from './stats.js';
+
+test('resetComputedStats restores effective stats to their base values', () => {
+  const character = new Character();
+
+  character.applyStatIncrease(STATS.STR);
+  character.applyStatIncrease(STATS.WIL);
+
+  assert.equal(character.getEffectiveStat(STATS.STR), 11);
+  assert.equal(character.getEffectiveStat(STATS.WIL), 11);
+
+  character.resetComputedStats();
+
+  assert.equal(character.getBaseStat(STATS.STR), 10);
+  assert.equal(character.getBaseStat(STATS.WIL), 10);
+  assert.equal(character.getEffectiveStat(STATS.STR), 10);
+  assert.equal(character.getEffectiveStat(STATS.WIL), 10);
+});
+
+test('applyStatIncrease changes only the effective value of the targeted stat', () => {
+  const character = new Character();
+
+  character.applyStatIncrease(STATS.AGI);
+  character.applyStatIncrease(STATS.AGI);
+  character.applyStatIncrease(STATS.PER);
+
+  assert.equal(character.getBaseStat(STATS.AGI), 10);
+  assert.equal(character.getBaseStat(STATS.PER), 10);
+  assert.equal(character.getEffectiveStat(STATS.AGI), 12);
+  assert.equal(character.getEffectiveStat(STATS.PER), 11);
+  assert.equal(character.getEffectiveStat(STATS.STR), 10);
+});

--- a/talent-calculator.js
+++ b/talent-calculator.js
@@ -328,6 +328,7 @@ class TalentCalculator extends HTMLElement {
   #requestStatUp(stat) {
     const res = this.#ledger.addStat(stat);
     if (!res.ok) return;
+    this.#recomputeCharacterFromLedger();
     this.#refreshAfterLedgerChange();
   }
 
@@ -335,6 +336,7 @@ class TalentCalculator extends HTMLElement {
   #requestStatDown(stat) {
     const res = this.#ledger.refundStat(stat);
     if (!res.ok) return;
+    this.#recomputeCharacterFromLedger();
     this.#refreshAfterLedgerChange();
   }
 
@@ -361,7 +363,7 @@ class TalentCalculator extends HTMLElement {
       /** @type {StatKey} */
       const stat = this.#getStatKey(btn);
 
-      const currentValue = this.#character.getBaseStat(stat) + (allocatedStats[stat] ?? 0);
+      const currentValue = this.#character.getEffectiveStat(stat);
 
       btn.disabled = remainingStatPoints === 0 || currentValue >= STAT_RULES.MAX_VALUE;
     });
@@ -392,16 +394,11 @@ class TalentCalculator extends HTMLElement {
   }
 
   #updateStatsDisplay() {
-    this.#strDisplay.textContent =
-      this.#character.getBaseStat(STATS.STR) + this.#ledger.getAllocatedStat(STATS.STR);
-    this.#agiDisplay.textContent =
-      this.#character.getBaseStat(STATS.AGI) + this.#ledger.getAllocatedStat(STATS.AGI);
-    this.#perDisplay.textContent =
-      this.#character.getBaseStat(STATS.PER) + this.#ledger.getAllocatedStat(STATS.PER);
-    this.#vitDisplay.textContent =
-      this.#character.getBaseStat(STATS.VIT) + this.#ledger.getAllocatedStat(STATS.VIT);
-    this.#wilDisplay.textContent =
-      this.#character.getBaseStat(STATS.WIL) + this.#ledger.getAllocatedStat(STATS.WIL);
+    this.#strDisplay.textContent = this.#character.getEffectiveStat(STATS.STR);
+    this.#agiDisplay.textContent = this.#character.getEffectiveStat(STATS.AGI);
+    this.#perDisplay.textContent = this.#character.getEffectiveStat(STATS.PER);
+    this.#vitDisplay.textContent = this.#character.getEffectiveStat(STATS.VIT);
+    this.#wilDisplay.textContent = this.#character.getEffectiveStat(STATS.WIL);
   }
 
   #updateStatIncreaseDisplay() {
@@ -551,9 +548,12 @@ class TalentCalculator extends HTMLElement {
   }
 
   #recomputeCharacterFromLedger() {
-    this.#character.retaliation = 1;
-    this.#character.openWeaponSkills = 0;
-    this.#character.openWeaponOneHandSkills = 0;
+    this.#character.resetComputedStats();
+
+    const statIncreases = this.#ledger.getStatIncreasesInOrder();
+    for (const { stat } of statIncreases) {
+      this.#character.applyStatIncrease(stat);
+    }
 
     const obtained = this.#ledger.getObtainedAbilitiesInOrder();
     for (const { abilityId } of obtained) {


### PR DESCRIPTION
## Summary
- Recompute effective main stats from the ledger
- Update formulas, displayed stats, and stat-cap checks to use recomputed values
- Add minimal tests for computed stat reset and stat allocation behavior

Closes #204 
