### PR TITLE
Apply passive and threshold bonuses from main stats

### DIFF
--- a/calculator/character.js
+++ b/calculator/character.js
@@ -33,43 +33,133 @@ export default class Character {
     this.perception = this.#baseStats[STATS.PER];
     this.vitality = this.#baseStats[STATS.VIT];
     this.willpower = this.#baseStats[STATS.WIL];
-    this.legsDef = 0;
-    this.knockbackChance = 0;
-    this.shieldBlockChance = 0;
-    this.maxBlockPower = 0;
-    this.blockChance = 0;
-    this.retaliation = 1;
+
+    // Combat
+    this.mainHandDamage = 7; // flat value
+    this.offHandDamage = 0; // flat value
+    this.weaponDamage = 100;
     this.mainHandEfficiency = 100;
     this.offHandEfficiency = 100;
-    this.bodyDef = 0;
+    this.bodypartDamage = 0;
+    this.armorDamage = 0;
+    this.armorPenetration = 0;
+    this.spellArmorPiercing = 0;
+
+    this.accuracy = 80;
+    this.spellAccuracy = 90;
+    this.critChance = 1;
+    this.critEfficiency = 25; // Stored as bonus percent; game displays +25%.
+    this.counterChance = 1;
+    this.fumbleChance = 20;
+
+    this.skillsEnergyCost = 0;
+    this.spellsEnergyCost = 0;
+    this.abilitiesEnergyCost = 100;
+    this.cooldownsDuration = 100;
+    this.maxVision = 12; // flat value
+    this.vision = 12; // flat value
+    this.bonusRange = 0; // Threshold bonus is flat +1, but the game displays this as %.
+
+    this.bleedChance = 0;
+    this.dazeChance = 0;
+    this.stunChance = 0;
+    this.knockbackChance = 0;
+    this.immobilizationChance = 0;
+    this.staggerChance = 0;
+
+    this.lifeDrain = 0;
+    this.energyDrain = 0;
+
+    // Survival
+    this.health = 100; // flat value; in the game, it shows as: 100/100; The second 100 must be max health.
+    this.maxHealth = 100; // flat value
+    this.healthRestoration = 10;
+    this.healingEfficiency = 100;
+
+    this.energy = 100; // flat value; in the game, it shows as: 100/100
+    this.maxEnergy = 100; // flat value
+    this.energyRestoration = 20;
+
+    this.protection = 0; // flat value
+    this.blockChance = 0;
+    this.blockPower = 0; // flat value; in the game, it shows as: 0/0; The second 0 must be max block power.
+    this.maxBlockPower = 0; // flat value
+    this.blockPowerRecovery = 0;
+
     this.dodgeChance = 1;
+    this.critAvoidance = 0;
+    this.fortitude = 0;
+
+    this.bleedResistance = 0;
+    this.controlResistance = 0;
+    this.moveResistance = 0;
+
+    this.hungerResistance = 0;
+    this.intoxicationResistance = 0;
+    this.painResistance = 0;
+    this.fatigueResistance = 0;
+
+    this.experienceGain = 100;
+    this.reputationGain = 100;
+
+    // Damage Resistance
+    this.damageTaken = 100;
+    this.damageReflection = 0;
+
+    this.physicalResistance = 0;
+    this.natureResistance = 0;
+    this.magicResistance = 0;
+
+    this.slashingResistance = 0;
+    this.piercingResistance = 0;
+    this.crushingResistance = 0;
+    this.rendingResistance = 0;
+
+    this.fireResistance = 0;
+    this.poisonResistance = 0;
+    this.frostResistance = 0;
+    this.shockResistance = 0;
+    this.causticResistance = 0;
+
+    this.arcaneResistance = 0;
+    this.sacredResistance = 0;
+    this.unholyResistance = 0;
+    this.psionicResistance = 0;
+
+    // Magic
     this.magicPower = 100;
     this.miracleChance = 5;
-    this.miraclePower = 25;
+    this.miraclePotency = 25; // Stored as bonus percent; game displays +25%.
     this.backfireChance = 20;
     this.backfireDamage = 5;
+
     this.pyromanticPower = 0;
     this.geomanticPower = 0;
+    this.venomanticPower = 0;
+    this.cryomanticPower = 0;
     this.electromanticPower = 0;
+
     this.arcanisticPower = 0;
+    this.astromanticPower = 0;
+    this.psimanticPower = 0;
+
+    // The following fields do not appear on the character sheet.
     this.fireDamageDefault = 1;
     this.fireDamage = 2;
     this.shockDamageDefault = 1;
     this.shockDamage = 2;
     this.arcaneDamageDefault = 1;
     this.arcaneDamage = 2;
-    this.hp = 100;
-    this.maxHP = 100;
-    this.mp = 100;
-    this.maxMP = 100;
-    this.accuracy = 0;
-    this.critChance = 0;
-    this.critPower = 125;
-    this.bonusRange = 0;
+
+    this.bodyDef = 0;
+    this.legsDef = 0;
+
+    this.shieldBlockChance = 0;
+    this.retaliation = 1;
+
     this.rangedSkillLearned = 0; // TODO: Does it count all ranged abilities learnt?
     this.openWeaponSkills = 0;
     this.openWeaponOneHandSkills = 0;
-    this.spellHitChance = 90;
   }
 
   /**
@@ -113,5 +203,16 @@ export default class Character {
     else if (stat === STATS.VIT) this.vitality++;
     else if (stat === STATS.WIL) this.willpower++;
     else throw new Error(`Unknown stat: ${stat}`);
+  }
+
+  /**
+   * Syncs current resources to their computed maximums.
+   *
+   * The calculator currently models a fully healthy / fully energized character
+   * rather than tracking damage or spent energy across recomputes.
+   */
+  syncCurrentResourcesToMaximums() {
+    this.health = this.maxHealth;
+    this.energy = this.maxEnergy;
   }
 }

--- a/calculator/stat-bonuses.js
+++ b/calculator/stat-bonuses.js
@@ -1,0 +1,146 @@
+import { STATS } from './stats.js';
+
+/**
+ * Main stat bonus rules are applied from the character's current effective stat values.
+ *
+ * - `perPoint` bonuses are applied once per stat point above the base value of 10.
+ * - `perThreshold` bonuses are applied once for each reached threshold in 15/20/25/30.
+ *
+ * A bonus can either target a single character field or provide a custom `apply`
+ * callback for cases that map to multiple fields.
+ */
+
+/**
+ * @typedef {{
+ *   amount: number,
+ *   field?: string,
+ *   apply?: (character: any, amount: number) => void
+ * }} StatBonusRule
+ */
+
+export const MAIN_STAT_THRESHOLDS = Object.freeze([15, 20, 25, 30]);
+
+export const MAIN_STAT_BONUSES = Object.freeze({
+  [STATS.STR]: {
+    perPoint: [
+      { field: 'blockChance', amount: 1.5 },
+      { field: 'weaponDamage', amount: 1.5 },
+    ],
+    perThreshold: [
+      { field: 'bodypartDamage', amount: 7.5 },
+      { field: 'critEfficiency', amount: 10 },
+      { field: 'armorDamage', amount: 15 },
+    ],
+  },
+
+  [STATS.AGI]: {
+    perPoint: [
+      { field: 'counterChance', amount: 1.5 },
+      { field: 'fumbleChance', amount: -1.5 },
+      { field: 'backfireChance', amount: -1.5 },
+    ],
+    perThreshold: [
+      { field: 'dodgeChance', amount: 5 },
+      {
+        amount: 2.5,
+        apply: (character, amount) => {
+          // Hands Efficiency affects both main-hand and off-hand values.
+          character.mainHandEfficiency += amount;
+          character.offHandEfficiency += amount;
+        },
+      },
+      { field: 'moveResistance', amount: 7.5 },
+    ],
+  },
+
+  [STATS.PER]: {
+    perPoint: [
+      { field: 'accuracy', amount: 1.5 },
+      { field: 'armorPenetration', amount: 1.5 },
+    ],
+    perThreshold: [
+      { field: 'vision', amount: 1 },
+      { field: 'bonusRange', amount: 1 },
+      { field: 'critChance', amount: 5 },
+      { field: 'miracleChance', amount: 5 },
+    ],
+  },
+
+  [STATS.VIT]: {
+    perPoint: [
+      { field: 'maxEnergy', amount: 4 },
+      { field: 'energyRestoration', amount: 2 },
+    ],
+    perThreshold: [
+      { field: 'maxHealth', amount: 15 },
+      { field: 'blockPowerRecovery', amount: 5 },
+      { field: 'controlResistance', amount: 7.5 },
+    ],
+  },
+
+  [STATS.WIL]: {
+    perPoint: [
+      { field: 'cooldownsDuration', amount: -1.5 },
+      { field: 'abilitiesEnergyCost', amount: -1.5 },
+    ],
+    perThreshold: [
+      { field: 'magicPower', amount: 7.5 },
+      { field: 'painResistance', amount: 7.5 },
+      { field: 'fortitude', amount: 7.5 },
+    ],
+  },
+});
+
+/**
+ * Returns how many main-stat thresholds have been reached by the given stat value.
+ *
+ * For example:
+ * - 14 => 0
+ * - 15 => 1
+ * - 20 => 2
+ * - 30 => 4
+ *
+ * @param {number} statValue
+ * @returns {number}
+ */
+export function countReachedMainStatThresholds(statValue) {
+  return MAIN_STAT_THRESHOLDS.filter((threshold) => statValue >= threshold).length;
+}
+
+function applyBonus(character, bonus, times) {
+  const totalAmount = bonus.amount * times;
+
+  if (typeof bonus.apply === 'function') {
+    bonus.apply(character, totalAmount);
+    return;
+  }
+
+  character[bonus.field] += totalAmount;
+}
+
+/**
+ * Applies all passive and threshold bonuses from the five main stats to the
+ * already-recomputed character snapshot.
+ *
+ * This is meant to run after ledger stat increases have been applied.
+ *
+ * @param {import('./character.js').default} character
+ */
+export function applyMainStatBonuses(character) {
+  for (const stat of Object.values(STATS)) {
+    const rules = MAIN_STAT_BONUSES[stat];
+    if (!rules) continue;
+
+    const statValue = character.getEffectiveStat(stat);
+    const thresholdCount = countReachedMainStatThresholds(statValue);
+    const bonusPointCount = Math.max(statValue - 10, 0);
+
+    for (const bonus of rules.perPoint) {
+      applyBonus(character, bonus, bonusPointCount);
+    }
+
+    for (const bonus of rules.perThreshold) {
+      applyBonus(character, bonus, thresholdCount);
+    }
+  }
+}

--- a/calculator/stat-bonuses.test.js
+++ b/calculator/stat-bonuses.test.js
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import Character from './character.js';
+import { applyMainStatBonuses, countReachedMainStatThresholds } from './stat-bonuses.js';
+import { STATS } from './stats.js';
+
+function makeCharacterWithStat(stat, value) {
+  const character = new Character();
+
+  for (let i = 10; i < value; i++) {
+    character.applyStatIncrease(stat);
+  }
+
+  applyMainStatBonuses(character);
+  return character;
+}
+
+test('countReachedMainStatThresholds counts thresholds at 15, 20, 25, and 30', () => {
+  assert.equal(countReachedMainStatThresholds(14), 0);
+  assert.equal(countReachedMainStatThresholds(15), 1);
+  assert.equal(countReachedMainStatThresholds(20), 2);
+  assert.equal(countReachedMainStatThresholds(25), 3);
+  assert.equal(countReachedMainStatThresholds(30), 4);
+});
+
+test('main stat per-point bonuses start above 10 rather than at the base value', () => {
+  const baseCharacter = makeCharacterWithStat(STATS.STR, 10);
+  const increasedCharacter = makeCharacterWithStat(STATS.STR, 11);
+
+  assert.equal(baseCharacter.blockChance, 0);
+  assert.equal(baseCharacter.weaponDamage, 100);
+
+  assert.equal(increasedCharacter.blockChance, 1.5);
+  assert.equal(increasedCharacter.weaponDamage, 101.5);
+});
+
+test('agility threshold bonuses apply at 15', () => {
+  const character = makeCharacterWithStat(STATS.AGI, 15);
+
+  assert.equal(character.dodgeChance, 6);
+  assert.equal(character.mainHandEfficiency, 102.5);
+  assert.equal(character.offHandEfficiency, 102.5);
+  assert.equal(character.moveResistance, 7.5);
+});
+
+test('perception threshold bonuses apply at 15', () => {
+  const character = makeCharacterWithStat(STATS.PER, 15);
+
+  assert.equal(character.vision, 13);
+  assert.equal(character.bonusRange, 1);
+  assert.equal(character.critChance, 6);
+  assert.equal(character.miracleChance, 10);
+});
+
+test('vitality bonuses apply both per point and at thresholds', () => {
+  const character = makeCharacterWithStat(STATS.VIT, 15);
+
+  assert.equal(character.maxEnergy, 120);
+  assert.equal(character.energyRestoration, 30);
+  assert.equal(character.maxHealth, 115);
+  assert.equal(character.blockPowerRecovery, 5);
+  assert.equal(character.controlResistance, 7.5);
+});
+
+test('willpower bonuses apply both per point and at thresholds', () => {
+  const character = makeCharacterWithStat(STATS.WIL, 15);
+
+  assert.equal(character.cooldownsDuration, 92.5);
+  assert.equal(character.abilitiesEnergyCost, 92.5);
+  assert.equal(character.magicPower, 107.5);
+  assert.equal(character.painResistance, 7.5);
+  assert.equal(character.fortitude, 7.5);
+});

--- a/components/stat-formula/stat-formula.js
+++ b/components/stat-formula/stat-formula.js
@@ -70,19 +70,19 @@ class StatFormula extends HTMLElement {
       formula = formula.replaceAll('Shock_DMG', this.#character.shockDamage);
       formula = formula.replaceAll('Arcane_DMG_Default', this.#character.arcaneDamageDefault);
       formula = formula.replaceAll('Arcane_DMG', this.#character.arcaneDamage);
-      formula = formula.replaceAll('HP', this.#character.hp);
-      formula = formula.replaceAll('max_hp', this.#character.maxHP);
-      formula = formula.replaceAll('MP', this.#character.mp);
-      formula = formula.replaceAll('max_mp', this.#character.maxMP);
+      formula = formula.replaceAll('HP', this.#character.health);
+      formula = formula.replaceAll('max_hp', this.#character.maxHealth);
+      formula = formula.replaceAll('MP', this.#character.energy);
+      formula = formula.replaceAll('max_mp', this.#character.maxEnergy);
       formula = formula.replaceAll('Miracle_Chance', this.#character.miracleChance);
-      formula = formula.replaceAll('Miracle_Power', this.#character.miraclePower);
+      formula = formula.replaceAll('Miracle_Power', this.#character.miraclePotency);
       formula = formula.replaceAll('ranged_skill_learned', this.#character.rangedSkillLearned);
       formula = formula.replaceAll('open_weapon_skills', this.#character.openWeaponSkills);
       formula = formula.replaceAll(
         'open_weapon_one_hand_skills',
         this.#character.openWeaponOneHandSkills,
       );
-      formula = formula.replaceAll('Spell_Hit_Chance', this.#character.spellHitChance);
+      formula = formula.replaceAll('Spell_Hit_Chance', this.#character.spellAccuracy);
     }
     if (this.#abilityPick) {
       formula = formula.replaceAll('Miscast_Chance', this.abilityPick.backfireChance);
@@ -91,11 +91,23 @@ class StatFormula extends HTMLElement {
     return formula;
   }
 
+  #roundResult(value) {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      return value;
+    }
+
+    return Number(value.toFixed(3));
+  }
+
   evalFormula() {
     this.#eval = this.#replaceStats(this.#formula.replaceAll('math_round', 'Math.round'));
-    this.#result = eval?.(`"use strict";(${this.#eval})`);
+
+    const rawResult = eval?.(`"use strict";(${this.#eval})`);
+    const roundedResult = this.#roundResult(rawResult);
+    this.#result = String(roundedResult);
+
     if (this.hasAttribute('plus')) {
-      this.#result = (this.#result <= 0 ? '' : '+') + this.#result; // Add plus sign in case of positive result.
+      this.#result = (roundedResult <= 0 ? '' : '+') + this.#result; // Add plus sign in case of positive result.
     }
     this.innerHTML = this.#result;
   }

--- a/components/tooltip-description/tooltip-description.js
+++ b/components/tooltip-description/tooltip-description.js
@@ -208,7 +208,7 @@ class TooltipDescription extends HTMLElement {
       .join('');
 
     if (formulaMap) {
-      html = html.replace(/<stat-formula>(.*?)<\/stat-formula>/g, (match, innerText) => {
+      englishTooltip = englishTooltip.replace(/<stat-formula>(.*?)<\/stat-formula>/g, (match, innerText) => {
         let formulaText = innerText;
         for (const [key, value] of Object.entries(formulaMap)) {
           formulaText = formulaText.replaceAll(key, value);

--- a/components/tooltip-description/tooltip-description.js
+++ b/components/tooltip-description/tooltip-description.js
@@ -208,13 +208,16 @@ class TooltipDescription extends HTMLElement {
       .join('');
 
     if (formulaMap) {
-      englishTooltip = englishTooltip.replace(/<stat-formula>(.*?)<\/stat-formula>/g, (match, innerText) => {
-        let formulaText = innerText;
-        for (const [key, value] of Object.entries(formulaMap)) {
-          formulaText = formulaText.replaceAll(key, value);
-        }
-        return `<stat-formula>${formulaText}</stat-formula>`;
-      });
+      englishTooltip = englishTooltip.replace(
+        /<stat-formula>(.*?)<\/stat-formula>/g,
+        (match, innerText) => {
+          let formulaText = innerText;
+          for (const [key, value] of Object.entries(formulaMap)) {
+            formulaText = formulaText.replaceAll(key, value);
+          }
+          return `<stat-formula>${formulaText}</stat-formula>`;
+        },
+      );
     }
     return englishTooltip;
   }

--- a/talent-calculator.js
+++ b/talent-calculator.js
@@ -7,6 +7,7 @@ import './components/tooltip-description/tooltip-description.js';
 import Character from './calculator/character.js';
 import { STATS, STAT_RULES } from './calculator/stats.js';
 import BuildLedger from './calculator/build-ledger.js';
+import { applyMainStatBonuses } from './calculator/stat-bonuses.js';
 
 import { APP_VERSION, APP_URL, REPO_NAME, REPO_OWNER } from './version.js';
 
@@ -555,10 +556,14 @@ class TalentCalculator extends HTMLElement {
       this.#character.applyStatIncrease(stat);
     }
 
+    applyMainStatBonuses(this.#character);
+
     const obtained = this.#ledger.getObtainedAbilitiesInOrder();
     for (const { abilityId } of obtained) {
       this.#applyEffectsForAbility(abilityId);
     }
+
+    this.#character.syncCurrentResourcesToMaximums();
 
     this.#updateShieldFormulas();
   }


### PR DESCRIPTION
## Summary
- apply passive and threshold bonuses from STR, AGI, PER, VIT, and WIL to the computed character state
- sync current health and energy to computed maximums after recompute

Closes #262
