### PR TITLE
Share Stoneshard tooltip HTML generation

### DIFF
--- a/components/tooltip-description/stoneshard-tooltip-to-html.js
+++ b/components/tooltip-description/stoneshard-tooltip-to-html.js
@@ -1,0 +1,96 @@
+const COLOR_CLASS_BY_CODE = {
+  lg: 'buff',
+  r: 'harm',
+  b: 'energy',
+  p: 'arcane',
+  o: 'fire',
+  y: 'geo',
+  ly: 'shock',
+  bl: 'energy',
+  ur: 'unholy',
+  g: 'caustic',
+};
+
+/**
+ * Converts a Stoneshard tooltip string and formula map into the HTML format used by index.html.
+ *
+ * @param {string} tooltipDescription
+ * @param {Record<string, string> | undefined} formulaMap
+ * @returns {string}
+ */
+export function stoneshardTooltipToHTML(tooltipDescription, formulaMap = {}) {
+  if (!tooltipDescription.trim()) return '';
+
+  const sortedFormulaMap = sortFormulaMap(formulaMap ?? {});
+
+  const html = tooltipDescription
+    .split('##')
+    .map((paragraph) => `<p>${formatParagraph(paragraph)}</p>\n\n`)
+    .join('');
+
+  return replaceFormulaKeysWithFormulas(html, sortedFormulaMap);
+}
+
+/**
+ * @param {Record<string, string>} formulaMap
+ * @returns {Record<string, string>}
+ */
+function sortFormulaMap(formulaMap) {
+  // Sort longer keys first so HP_Limit cannot replace part of Max_HP_Limit.
+  return Object.fromEntries(
+    Object.entries(formulaMap).sort(([keyA], [keyB]) => keyB.length - keyA.length),
+  );
+}
+
+/**
+ * @param {string} paragraph
+ * @returns {string}
+ */
+function formatParagraph(paragraph) {
+  return paragraph
+    .trim()
+    .replace(/#/g, '<br>\n')
+    .replace(/~([a-z]+)~(.*?)~\/~/g, (match, color, text) => replaceTag(color, text));
+}
+
+/**
+ * @param {string} html
+ * @param {Record<string, string>} formulaMap
+ * @returns {string}
+ */
+function replaceFormulaKeysWithFormulas(html, formulaMap) {
+  return html.replace(
+    /<stat-formula([^>]*)>(.*?)<\/stat-formula>/g,
+    (match, attributes, innerText) => {
+      let formulaText = innerText;
+      for (const [key, value] of Object.entries(formulaMap)) {
+        formulaText = formulaText.replaceAll(key, value);
+      }
+      return `<stat-formula${attributes}>${formulaText}</stat-formula>`;
+    },
+  );
+}
+
+/**
+ * @param {string} color
+ * @param {string} text
+ * @returns {string}
+ */
+function replaceTag(color, text) {
+  text = text.replace(/\/\*([^*]+)\*\//g, (match, formulaKey) => {
+    return `<stat-formula formula-key="${formulaKey}">${formulaKey}</stat-formula>`;
+  });
+
+  if (color === 'w') {
+    return `<strong>${text}</strong>`;
+  }
+  return `<span class="${getSpanClass(color)}">${text}</span>`;
+}
+
+/**
+ * @param {string} colorCode
+ * @returns {string}
+ */
+function getSpanClass(colorCode) {
+  return COLOR_CLASS_BY_CODE[colorCode] || 'unknown-tag';
+}

--- a/components/tooltip-description/stoneshard-tooltip-to-html.test.js
+++ b/components/tooltip-description/stoneshard-tooltip-to-html.test.js
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { stoneshardTooltipToHTML } from './stoneshard-tooltip-to-html.js';
+
+test('stoneshardTooltipToHTML preserves formula keys while replacing formula text', () => {
+  const tooltip = 'Deals ~o~/*Fire_Damage*/ Fire Damage~/~ with ~w~/*Hit_Chance*/%~/~ Accuracy.';
+  const formulaMap = {
+    Fire_Damage: '(7 * Magic_Power / 100)',
+    Hit_Chance: '100',
+  };
+
+  assert.equal(
+    stoneshardTooltipToHTML(tooltip, formulaMap),
+    '<p>Deals <span class="fire"><stat-formula formula-key="Fire_Damage">(7 * Magic_Power / 100)</stat-formula> Fire Damage</span> with <strong><stat-formula formula-key="Hit_Chance">100</stat-formula>%</strong> Accuracy.</p>\n\n',
+  );
+});
+
+test('stoneshardTooltipToHTML replaces longer formula keys first', () => {
+  const tooltip = 'Limits damage to ~w~/*Max_HP_Limit*/~/~.';
+  const formulaMap = {
+    HP_Limit: '16',
+    Max_HP_Limit: 'math_round(20 * Magic_Power / 100)',
+  };
+
+  assert.equal(
+    stoneshardTooltipToHTML(tooltip, formulaMap),
+    '<p>Limits damage to <strong><stat-formula formula-key="Max_HP_Limit">math_round(20 * Magic_Power / 100)</stat-formula></strong>.</p>\n\n',
+  );
+});

--- a/components/tooltip-description/tooltip-description.js
+++ b/components/tooltip-description/tooltip-description.js
@@ -1,3 +1,5 @@
+import { stoneshardTooltipToHTML } from './stoneshard-tooltip-to-html.js';
+
 class TooltipDescription extends HTMLElement {
   #source = '';
   #result = '';
@@ -171,80 +173,10 @@ class TooltipDescription extends HTMLElement {
       const formulas = input[0];
       description = input[1];
       formulaMap = this.#parseFormulas(formulas);
-      // Sort so that formulas with longer keys appear first to avoid the case where a formula like HP_Limit
-      // would be applied before Max_HP_Limit and replace part of the longer formula.
-      formulaMap = Object.fromEntries(
-        Object.entries(formulaMap).sort(([keyA], [keyB]) => keyB.length - keyA.length),
-      );
     }
     const data = description.split(';');
-    const tooltip = {
-      key: data[0].trim(),
-      russian: data[1],
-      english: data[2],
-      chinese: data[3],
-      german: data[4],
-      spanish: data[5],
-      french: data[6],
-      italian: data[7],
-      portuguese: data[8],
-      polish: data[9],
-      turkish: data[10],
-      japanese: data[11],
-      korean: data[12],
-    };
 
-    let englishTooltip = tooltip.english
-      .split('##')
-      .map(
-        (paragraph) =>
-          `<p>${paragraph
-            .trim()
-            .replace(/#/g, '<br>\n')
-            .replace(/~([a-z]+)~(.*?)~\/~/g, (match, color, text) =>
-              this.#replaceTag(color, text),
-            )}</p>\n\n`,
-      )
-      .join('');
-
-    if (formulaMap) {
-      englishTooltip = englishTooltip.replace(
-        /<stat-formula([^>]*)>(.*?)<\/stat-formula>/g,
-        (match, attributes, innerText) => {
-          let formulaText = innerText;
-          for (const [key, value] of Object.entries(formulaMap)) {
-            formulaText = formulaText.replaceAll(key, value);
-          }
-          return `<stat-formula${attributes}>${formulaText}</stat-formula>`;
-        },
-      );
-    }
-    return englishTooltip;
-  }
-
-  #replaceTag(color, text) {
-    text = text.replace(/\/\*([^*]+)\*\//g, (match, formulaKey) => {
-      return `<stat-formula formula-key="${formulaKey}">${formulaKey}</stat-formula>`;
-    });
-
-    if (color === 'w') {
-      return `<strong>${text}</strong>`;
-    }
-    return `<span class="${this.#getSpanClass(color)}">${text}</span>`;
-  }
-
-  #getSpanClass(colorCode) {
-    const colorMap = {
-      lg: 'buff',
-      r: 'harm',
-      b: 'energy',
-      p: 'arcane',
-      o: 'fire',
-      y: 'geo',
-      ly: 'shock',
-      bl: 'energy',
-    };
-    return colorMap[colorCode] || 'unknown-tag';
+    return stoneshardTooltipToHTML(data[2], formulaMap);
   }
 
   /**

--- a/tooltips/Dockerfile
+++ b/tooltips/Dockerfile
@@ -5,7 +5,9 @@ WORKDIR /src
 COPY tooltips/stoneshard-tooltips-and-formulas.json .
 COPY tooltips/package.json .
 COPY .prettierrc.json .
- 
+
 RUN npm install
+
+COPY components/tooltip-description/stoneshard-tooltip-to-html.js /components/tooltip-description/stoneshard-tooltip-to-html.js
 
 ENTRYPOINT ["node", "compare-tooltips.js"]

--- a/tooltips/compare-tooltips.js
+++ b/tooltips/compare-tooltips.js
@@ -1,7 +1,7 @@
 // Build
 // -----
 //
-// Build the container once:
+// Build or rebuild the container after changing dependencies or the shared tooltip formatter:
 //
 // docker build -t compare-tooltips -f tooltips/Dockerfile .
 //
@@ -36,6 +36,8 @@
 import fs from 'fs';
 import * as cheerio from 'cheerio';
 import * as prettier from 'prettier';
+
+import { stoneshardTooltipToHTML } from '../components/tooltip-description/stoneshard-tooltip-to-html.js';
 
 /**
  * @typedef {Object.<string, SkillData[]>} GameData
@@ -372,77 +374,4 @@ function setOrRemoveAttribute(element, attributeName, value) {
   }
 
   element.attr(attributeName, value);
-}
-
-/**
- * Converts a Stoneshard tooltip string and formula map into the HTML format used by index.html.
- *
- * @param {string} tooltipDescription
- * @param {FormulaMap | undefined} formulaMap
- * @returns {string}
- */
-function stoneshardTooltipToHTML(tooltipDescription, formulaMap) {
-  if (!tooltipDescription.trim()) return '';
-
-  if (!formulaMap) formulaMap = {};
-
-  // Sort so that formulas with longer keys appear first to avoid the case where a formula like HP_Limit
-  // would be applied before Max_HP_Limit and replace part of the longer formula.
-  formulaMap = Object.fromEntries(
-    Object.entries(formulaMap).sort(([keyA], [keyB]) => keyB.length - keyA.length),
-  );
-
-  let html = tooltipDescription
-    .split('##')
-    .map(
-      (paragraph) =>
-        `<p>${paragraph
-          .trim()
-          .replace(/#/g, '<br>\n')
-          .replace(/~([a-z]+)~(.*?)~\/~/g, (match, color, text) =>
-            replaceTag(color, text),
-          )}</p>\n\n`,
-    )
-    .join('');
-
-  if (formulaMap) {
-    html = html.replace(
-      /<stat-formula([^>]*)>(.*?)<\/stat-formula>/g,
-      (match, attributes, innerText) => {
-        let formulaText = innerText;
-        for (const [key, value] of Object.entries(formulaMap)) {
-          formulaText = formulaText.replaceAll(key, value);
-        }
-        return `<stat-formula${attributes}>${formulaText}</stat-formula>`;
-      },
-    );
-  }
-  return html;
-}
-
-function replaceTag(color, text) {
-  text = text.replace(/\/\*([^*]+)\*\//g, (match, formulaKey) => {
-    return `<stat-formula formula-key="${formulaKey}">${formulaKey}</stat-formula>`;
-  });
-
-  if (color === 'w') {
-    return `<strong>${text}</strong>`;
-  }
-  return `<span class="${getSpanClass(color)}">${text}</span>`;
-}
-
-function getSpanClass(colorCode) {
-  const colorMap = {
-    lg: 'buff',
-    r: 'harm',
-    b: 'energy',
-    p: 'arcane',
-    o: 'fire',
-    y: 'geo',
-    ly: 'shock',
-    bl: 'energy',
-    ur: 'unholy',
-    g: 'caustic',
-  };
-  return colorMap[colorCode] || 'unknown-tag';
 }


### PR DESCRIPTION
Extracts the Stoneshard tooltip-to-HTML conversion into a shared pure module used by both the runtime tooltip component and the tooltip comparison script.

This removes duplicated formula-key handling and keeps future tooltip generation changes in one place.

Adds focused tests for preserving `formula-key` metadata and replacing longer formula keys before shorter ones.

Closes #268
