### PR TITLE
Add unlock requirement metadata to ability-pick elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -552,6 +552,9 @@
           target="No Target"
           requires="Requires a one-handed sword"
           tooltip-left
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -637,6 +640,9 @@
           modifiers="Strength, Agility, Perception"
           requires="Requires a one-handed sword"
           tooltip-left
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -848,6 +854,9 @@
           target="No Target"
           requires="Requires a one-handed axe"
           tooltip-left
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>Activates <span class="buff">"Massacre"</span> for <strong>10</strong> turns:</p>
@@ -888,6 +897,9 @@
           modifiers="Strength, Agility, Perception, Willpower"
           requires="Requires a one-handed axe"
           tooltip-top-right
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="STR AGI PER WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -1124,6 +1136,9 @@
           cooldown="12"
           requires="Requires a one-handed mace"
           tooltip-left
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -1166,6 +1181,9 @@
           modifiers="Strength, Agility, Perception"
           requires="Requires a one-handed mace"
           tooltip-top-right
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -1378,6 +1396,9 @@
           modifiers="Strength, Agility, Perception"
           requires="Requires a dagger"
           tooltip-right
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -1445,6 +1466,9 @@
           target="No Target"
           requires="Requires a dagger"
           tooltip-left
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -1531,6 +1555,9 @@
           modifiers="Strength, Agility, Perception"
           requires="Requires a dagger"
           tooltip-top-left
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -1713,6 +1740,9 @@
           cooldown="12"
           requires="Requires a two-handed sword"
           tooltip-mid-right
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -1758,6 +1788,9 @@
           modifiers="Strength, Agility, Perception, Willpower"
           requires="Requires a two-handed sword"
           tooltip-mid-left
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -1856,6 +1889,9 @@
           modifiers="Strength, Agility, Perception"
           requires="Requires a two-handed sword"
           tooltip-top
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -2052,6 +2088,9 @@
           cooldown="12"
           requires="Requires a two-handed axe"
           tooltip-mid-right
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>Activates <span class="buff">"Rampage"</span> for <strong>10</strong> turns:</p>
@@ -2148,6 +2187,9 @@
           modifiers="Strength, Agility, Perception, Willpower"
           requires="Requires a two-handed axe"
           tooltip-mid-left
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -2225,6 +2267,9 @@
           modifiers="Strength, Agility, Perception"
           requires="Requires a two-handed axe"
           tooltip-top-right
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -2420,6 +2465,9 @@
           cooldown="12"
           requires="Requires a two-handed mace"
           tooltip-right
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -2495,6 +2543,9 @@
           modifiers="Strength, Agility, Perception"
           requires="Requires a two-handed mace"
           tooltip-left
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -2587,6 +2638,9 @@
           modifiers="Strength, Agility, Perception"
           requires="Requires a two-handed mace"
           tooltip-top
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -2800,6 +2854,9 @@
           cooldown="12"
           requires="Requires a spear"
           tooltip-mid-right
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="STR PER VIT"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -2867,6 +2924,9 @@
           modifiers="Perception, Agility, Strength, Willpower"
           requires="Requires a spear"
           tooltip-mid-left
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="STR AGI PER WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>Activates <span class="buff">"Determination"</span> for <strong>2</strong> turns:</p>
@@ -2931,6 +2991,9 @@
           modifiers="Vitality"
           requires="Requires a spear"
           tooltip-top-right
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="STR AGI VIT"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -3211,6 +3274,9 @@
           modifiers="Strength, Agility, Perception"
           requires="Requires a ranged weapon and ammunition"
           tooltip-mid-right
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -3266,6 +3332,9 @@
           cooldown="10"
           requires="Requires a ranged weapon and ammunition"
           tooltip-mid-left
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -3346,6 +3415,9 @@
           modifiers="Strength, Agility, Perception"
           requires="Requires a ranged weapon and ammunition"
           tooltip-top-right
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>Takes a shot with <span class="buff">+2</span> Range.</p>
@@ -3436,6 +3508,9 @@
           cooldown="16"
           requires="Requires a ranged weapon and ammunition"
           tooltip-mid-left
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -3517,6 +3592,9 @@
           modifiers="Strength, Agility, Perception"
           requires="Requires a ranged weapon and ammunition"
           tooltip-top
+          unlock-level="22"
+          unlock-attribute-points="20"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -3801,6 +3879,9 @@
           modifiers="Strength, Perception, Vitality, Block Chance, Block Power"
           requires="Requires a shield"
           tooltip-mid-right
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -3863,6 +3944,9 @@
           modifiers="Vitality"
           requires="Requires a shield"
           tooltip-mid-right
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="STR VIT WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -4112,6 +4196,9 @@
           cooldown="12"
           requires="Requires a staff"
           tooltip-mid-right
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="STR AGI VIT WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -4185,6 +4272,9 @@
           modifiers="Strength, Agility, Perception"
           requires="Requires a staff"
           tooltip-top-right
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="STR AGI WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -4392,6 +4482,9 @@
           modifiers="Agility, Perception, Vitality"
           requires="Requires dual weapons"
           tooltip-right
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -4439,6 +4532,9 @@
           cooldown="12"
           requires="Requires dual weapons"
           tooltip-mid-right
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="AGI PER WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -4537,6 +4633,9 @@
           modifiers="Strength, Agility, Perception"
           requires="Requires dual weapons"
           tooltip-top-right
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -4829,6 +4928,9 @@
           modifiers="Agility, Perception, Vitality, Willpower"
           requires="Requires an Injury or damaged Health"
           tooltip-mid-left
+          unlock-level="6"
+          unlock-attribute-points="4"
+          unlock-attributes="AGI PER VIT WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>Stabilizes all <span class="harm">Injuries</span>.</p>
@@ -4981,6 +5083,9 @@
           modifiers="Vitality, Willpower"
           requires="Requires a negative effect or damaged Health"
           tooltip-top-left
+          unlock-level="8"
+          unlock-attribute-points="6"
+          unlock-attributes="VIT WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -5232,6 +5337,9 @@
           energy="20"
           cooldown="28"
           tooltip-right
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="STR AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -5282,6 +5390,9 @@
           energy="20"
           cooldown="28"
           tooltip-right
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="AGI VIT WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -5360,6 +5471,9 @@
           cooldown="18"
           modifiers="Strength, Agility, Perception, Willpower"
           tooltip-top-right
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="STR AGI PER WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -5470,6 +5584,9 @@
           energy="12"
           cooldown="60"
           tooltip-top-left
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="VIT WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -5546,6 +5663,9 @@
           energy="30"
           cooldown="30"
           tooltip-top-right
+          unlock-level="22"
+          unlock-attribute-points="20"
+          unlock-attributes="STR AGI VIT WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -5819,6 +5939,9 @@
           target="Target Tile"
           range="4"
           tooltip-right
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="AGI VIT"
         >
           <div slot="description" class="tooltip-description">
             <p>Performs a <strong>charge</strong> towards the targeted tile.</p>
@@ -5877,6 +6000,9 @@
           range="1"
           modifiers="Agility, Perception"
           tooltip-left
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -5944,6 +6070,9 @@
           target="No Target"
           modifiers="Agility, Vitality, Perception"
           tooltip-top-right
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="AGI PER VIT"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -6041,6 +6170,9 @@
           target="No Target"
           modifiers="Vitality, Willpower"
           tooltip-top-right
+          unlock-level="22"
+          unlock-attribute-points="20"
+          unlock-attributes="STR VIT WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -6278,6 +6410,9 @@
           backfire-chance="5"
           backfire-damage-type="arcane"
           tooltip-right
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="PER WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -6356,6 +6491,9 @@
           backfire-damage-type="arcane"
           modifiers="Vitality, Willpower, Bonus Range"
           tooltip-left
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="PER WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -6471,6 +6609,9 @@
           backfire-damage-type="arcane"
           modifiers="Bonus Range"
           tooltip-left
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="VIT WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -6504,6 +6645,9 @@
           backfire-damage-type="arcane"
           modifiers="Willpower, Bonus Range"
           tooltip-top-right
+          unlock-level="22"
+          unlock-attribute-points="20"
+          unlock-attributes="PER WIL AGI"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -6687,6 +6831,9 @@
           cooldown="14"
           modifiers="Agility, Perception, Willpower"
           tooltip-right
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="AGI PER WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -6788,6 +6935,9 @@
           energy="20"
           cooldown="14"
           tooltip-mid-left
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="STR AGI VIT"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -6826,6 +6976,9 @@
           cooldown="24"
           modifiers="Strength, Agility, Perception, Vitality, Dodge Chance"
           tooltip-mid-right
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="STR AGI PER VIT"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -7110,6 +7263,9 @@
           armor-penetration="5"
           modifiers="Magic Power, Pyromantic Power"
           tooltip-mid-right
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="AGI WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -7150,6 +7306,9 @@
           armor-penetration="-10"
           modifiers="Magic Power, Pyromantic Power, Bonus Range"
           tooltip-mid-left
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="PER WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -7228,6 +7387,9 @@
           armor-penetration="25"
           modifiers="Magic Power, Pyromantic Power, Bonus Range"
           tooltip-top-right
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="AGI WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -7299,6 +7461,9 @@
           armor-penetration="15"
           modifiers="Magic Power, Pyromantic Power, Bonus Range"
           tooltip-top-left
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="PER WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -7378,6 +7543,9 @@
           armor-penetration="10"
           modifiers="Magic Power, Pyromantic Power, Bonus Range"
           tooltip-top
+          unlock-level="22"
+          unlock-attribute-points="20"
+          unlock-attributes="AGI WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -7607,6 +7775,9 @@
           armor-penetration="15"
           modifiers="Magic Power, Geomantic Power, Bonus Range"
           tooltip-mid-right
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="AGI VIT WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -7700,6 +7871,9 @@
           armor-penetration="25"
           modifiers="Magic Power, Geomantic Power, Bonus Range, Willpower"
           tooltip-mid-right
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="AGI VIT WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -7804,6 +7978,9 @@
           armor-penetration="0"
           modifiers="Magic Power, Geomantic Power"
           tooltip-mid-left
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="PER VIT WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -7872,6 +8049,9 @@
           armor-penetration="20"
           modifiers="Magic Power, Geomantic Power, Bonus Range"
           tooltip-top-right
+          unlock-level="22"
+          unlock-attribute-points="20"
+          unlock-attributes="VIT WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -7931,6 +8111,9 @@
           armor-penetration="15"
           modifiers="Magic Power, Geomantic Power, Bonus Range"
           tooltip-top-left
+          unlock-level="22"
+          unlock-attribute-points="20"
+          unlock-attributes="PER WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -8207,6 +8390,9 @@
           armor-penetration="65"
           modifiers="Magic Power, Electromantic Power"
           tooltip-right
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="AGI PER WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -8255,6 +8441,9 @@
           armor-penetration="50"
           modifiers="Magic Power, Electromantic Power"
           tooltip-left
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="AGI PER WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -8339,6 +8528,9 @@
           armor-penetration="45"
           modifiers="Magic Power, Electromantic Power, Bonus Range"
           tooltip-mid-right
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="PER WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -8444,6 +8636,9 @@
           armor-penetration="20"
           modifiers="Magic Power, Electromantic Power"
           tooltip-mid-left
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="AGI WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -8545,6 +8740,9 @@
           armor-penetration="30"
           modifiers="Magic Power, Electromantic Power, Bonus Range"
           tooltip-top-left
+          unlock-level="22"
+          unlock-attribute-points="20"
+          unlock-attributes="AGI WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -8821,6 +9019,9 @@
           armor-penetration="50"
           modifiers="Magic Power, Arcanistic Power, Bonus Range"
           tooltip-right
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="WIL STR AGI"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -8898,6 +9099,9 @@
           backfire-damage-type="arcane"
           modifiers="Magic Power, Arcanistic Power, Willpower"
           tooltip-left
+          unlock-level="10"
+          unlock-attribute-points="8"
+          unlock-attributes="WIL STR"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -9001,6 +9205,9 @@
           backfire-damage-type="arcane"
           modifiers="Magic Power, Arcanistic Power, Perception, Willpower, Backfire Chance, Miracle Chance, Miracle Potency, Bonus Range"
           tooltip-bottom
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="WIL AGI PER"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -9072,6 +9279,9 @@
           backfire-damage-type="arcane"
           modifiers="Magic Power, Arcanistic Power, Bonus Range"
           tooltip-left
+          unlock-level="16"
+          unlock-attribute-points="14"
+          unlock-attributes="WIL AGI"
         >
           <div slot="description" class="tooltip-description">
             <p>
@@ -9131,6 +9341,9 @@
           backfire-damage-type="arcane"
           modifiers="Magic Power, Arcanistic Power, Perception, Willpower, Backfire Chance, Miracle Chance, Miracle Potency, Bonus Range"
           tooltip-right
+          unlock-level="22"
+          unlock-attribute-points="20"
+          unlock-attributes="WIL"
         >
           <div slot="description" class="tooltip-description">
             <p>

--- a/tooltips/compare-tooltips.js
+++ b/tooltips/compare-tooltips.js
@@ -50,6 +50,7 @@ import { stoneshardTooltipToHTML } from '../components/tooltip-description/stone
  * @property {FormulaMap} [formulas]
  * @property {boolean} is_passive
  * @property {SkillAttributes} [attributes]
+ * @property {UnlockRequirements} [unlock_requirements]
  */
 
 /**
@@ -74,6 +75,13 @@ import { stoneshardTooltipToHTML } from '../components/tooltip-description/stone
  * @property {string} fumble_chance
  * @property {string} armor_penetration
  * @property {string} spell
+ */
+
+/**
+ * @typedef {Object} UnlockRequirements
+ * @property {number} level
+ * @property {number} attribute_points
+ * @property {string[]} attributes
  */
 
 main().catch((e) => {
@@ -285,10 +293,66 @@ function humanize(s) {
  * @returns {boolean} True if any compared attribute differs from the HTML version.
  */
 function compareAttributes(abilityPickElement, skill, compareTitle, write) {
+  const unlockRequirementsChanged = compareUnlockRequirementAttributes(
+    abilityPickElement,
+    skill,
+    compareTitle,
+    write,
+  );
+
   if (skill.is_passive) {
-    return false;
+    return unlockRequirementsChanged;
   }
 
+  const activeSkillAttributesChanged = compareActiveSkillAttributes(
+    abilityPickElement,
+    skill,
+    compareTitle,
+    write,
+  );
+
+  return unlockRequirementsChanged || activeSkillAttributesChanged;
+}
+
+function compareUnlockRequirementAttributes(abilityPickElement, skill, compareTitle, write) {
+  const requirements = skill.unlock_requirements;
+  const wantUnlockLevel = requirements ? String(requirements.level) : undefined;
+  const wantUnlockAttributePoints = requirements
+    ? String(requirements.attribute_points)
+    : undefined;
+  const wantUnlockAttributes = requirements ? requirements.attributes.join(' ') : undefined;
+
+  let haveChanges = false;
+
+  haveChanges =
+    compareAndSyncAttribute(
+      abilityPickElement,
+      'unlock-level',
+      wantUnlockLevel,
+      compareTitle,
+      write,
+    ) || haveChanges;
+  haveChanges =
+    compareAndSyncAttribute(
+      abilityPickElement,
+      'unlock-attribute-points',
+      wantUnlockAttributePoints,
+      compareTitle,
+      write,
+    ) || haveChanges;
+  haveChanges =
+    compareAndSyncAttribute(
+      abilityPickElement,
+      'unlock-attributes',
+      wantUnlockAttributes,
+      compareTitle,
+      write,
+    ) || haveChanges;
+
+  return haveChanges;
+}
+
+function compareActiveSkillAttributes(abilityPickElement, skill, compareTitle, write) {
   const haveTarget = abilityPickElement.attr('target');
   const haveEnergy = abilityPickElement.attr('energy');
   const haveCooldown = abilityPickElement.attr('cooldown');
@@ -349,6 +413,24 @@ function compareAttributes(abilityPickElement, skill, compareTitle, write) {
   }
 
   return haveChanges;
+}
+
+function compareAndSyncAttribute(element, attributeName, wantValue, compareTitle, write) {
+  const haveValue = element.attr(attributeName);
+
+  if (haveValue === wantValue) {
+    return false;
+  }
+
+  console.log(compareTitle);
+  console.log(`Have ${attributeName}:`, haveValue);
+  console.log(`Want ${attributeName}:`, wantValue);
+
+  if (write) {
+    setOrRemoveAttribute(element, attributeName, wantValue);
+  }
+
+  return true;
 }
 
 function normalizeTarget(target) {


### PR DESCRIPTION
## Summary

- Update the tooltip compare script to write unlock requirement metadata to `<ability-pick>` elements.
- Add `unlock-level`, `unlock-attribute-points`, and `unlock-attributes` attributes to generated ability markup.
- Support unlock metadata for both active and passive abilities.

## Notes

This only adds the metadata to `index.html`. Rendering unlock requirements in tooltips and enforcing unlock logic are out of scope.

Closes #274 
