### PR TITLE
Update unlock requirement tooltips from character state

### DIFF
--- a/calculator/ability-unlock-requirements.js
+++ b/calculator/ability-unlock-requirements.js
@@ -1,0 +1,47 @@
+/**
+ * @typedef {import('./character.js').default} Character
+ * @typedef {import('./stats.js').StatKey} StatKey
+ *
+ * @typedef {{
+ *   level: number,
+ *   attributePoints: number,
+ *   attributes: StatKey[],
+ * }} AbilityUnlockRequirements
+ *
+ * @typedef {{
+ *   isSatisfied: boolean,
+ *   remainingAttributePoints: number,
+ * }} AbilityUnlockRequirementState
+ */
+
+/**
+ * Computes the current display state for an ability unlock requirement.
+ *
+ * Attribute requirements use the combined invested points across all listed attributes.
+ *
+ * @param {AbilityUnlockRequirements} requirements
+ * @param {Character} character
+ * @param {number} currentLevel
+ * @returns {AbilityUnlockRequirementState}
+ */
+export function computeAbilityUnlockRequirementState(requirements, character, currentLevel) {
+  const isLevelSatisfied = currentLevel >= requirements.level;
+
+  let investedAttributePoints = 0;
+  for (const attribute of requirements.attributes) {
+    investedAttributePoints += Math.max(
+      character.getEffectiveStat(attribute) - character.getBaseStat(attribute),
+      0,
+    );
+  }
+
+  const remainingAttributePoints = Math.max(
+    requirements.attributePoints - investedAttributePoints,
+    0,
+  );
+
+  return {
+    isSatisfied: isLevelSatisfied || remainingAttributePoints === 0,
+    remainingAttributePoints,
+  };
+}

--- a/calculator/ability-unlock-requirements.test.js
+++ b/calculator/ability-unlock-requirements.test.js
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { computeAbilityUnlockRequirementState } from './ability-unlock-requirements.js';
+import Character from './character.js';
+import { STATS } from './stats.js';
+
+test('unlock requirement shows all required attribute points before any are invested', () => {
+  const character = new Character();
+
+  const state = computeAbilityUnlockRequirementState(
+    {
+      level: 10,
+      attributePoints: 8,
+      attributes: [STATS.STR, STATS.AGI],
+    },
+    character,
+    1,
+  );
+
+  assert.deepEqual(state, {
+    isSatisfied: false,
+    remainingAttributePoints: 8,
+  });
+});
+
+test('unlock requirement is satisfied by combined points across listed attributes', () => {
+  const character = new Character();
+
+  for (let i = 0; i < 4; i++) {
+    character.applyStatIncrease(STATS.STR);
+    character.applyStatIncrease(STATS.AGI);
+  }
+
+  const state = computeAbilityUnlockRequirementState(
+    {
+      level: 10,
+      attributePoints: 8,
+      attributes: [STATS.STR, STATS.AGI],
+    },
+    character,
+    1,
+  );
+
+  assert.deepEqual(state, {
+    isSatisfied: true,
+    remainingAttributePoints: 0,
+  });
+});
+
+test('reaching the required level satisfies the unlock requirement', () => {
+  const character = new Character();
+
+  const state = computeAbilityUnlockRequirementState(
+    {
+      level: 10,
+      attributePoints: 8,
+      attributes: [STATS.STR, STATS.AGI],
+    },
+    character,
+    10,
+  );
+
+  assert.deepEqual(state, {
+    isSatisfied: true,
+    remainingAttributePoints: 8,
+  });
+});
+
+test('remaining attribute points never drops below zero', () => {
+  const character = new Character();
+
+  for (let i = 0; i < 10; i++) {
+    character.applyStatIncrease(STATS.STR);
+  }
+
+  const state = computeAbilityUnlockRequirementState(
+    {
+      level: 10,
+      attributePoints: 8,
+      attributes: [STATS.STR, STATS.AGI],
+    },
+    character,
+    1,
+  );
+
+  assert.deepEqual(state, {
+    isSatisfied: true,
+    remainingAttributePoints: 0,
+  });
+});

--- a/components/ability-pick/ability-pick.js
+++ b/components/ability-pick/ability-pick.js
@@ -1,5 +1,6 @@
 import Character from '../../calculator/character.js';
 import { computeAbilityTooltipValues } from '../../calculator/ability-tooltip-values.js';
+import { computeAbilityUnlockRequirementState } from '../../calculator/ability-unlock-requirements.js';
 import { STAT_LABELS } from '../../calculator/stats.js';
 
 /**
@@ -57,6 +58,8 @@ export class AbilityPick extends HTMLElement {
   #unlockAttributePoints = null;
   #unlockAttributes = [];
   #tooltipValues = null;
+  #unlockRequirementsSectionElement = null;
+  #unlockRequirementAttributePointsElement = null;
   #energyValueElement = null;
   #cooldownValueElement = null;
   #backfireChanceValueElement = null;
@@ -546,6 +549,12 @@ export class AbilityPick extends HTMLElement {
     this.#armorPenetrationValueElement = tooltip.querySelector(
       '[data-role="armor-penetration-value"]',
     );
+    this.#unlockRequirementsSectionElement = tooltip.querySelector(
+      '[data-role="unlock-requirements-section"]',
+    );
+    this.#unlockRequirementAttributePointsElement = tooltip.querySelector(
+      '[data-role="unlock-requirement-attribute-points"]',
+    );
 
     return tooltip;
   }
@@ -567,10 +576,12 @@ export class AbilityPick extends HTMLElement {
       .join(', ');
 
     return `
-      <hr>
-      <p class="unlock-requirements">
-        Read the corresponding treatise to unlock this Ability, reach level <span class="unlock-requirement-value">${this.#unlockLevel}</span> or invest at least <span class="unlock-requirement-value">${this.#unlockAttributePoints}</span> more points into the following attributes: ${attributes}.
-      </p>
+      <section data-role="unlock-requirements-section">
+        <hr>
+        <p class="unlock-requirements">
+          Read the corresponding treatise to unlock this Ability, reach level <span class="unlock-requirement-value">${this.#unlockLevel}</span> or invest at least <span class="unlock-requirement-value" data-role="unlock-requirement-attribute-points">${this.#unlockAttributePoints}</span> more points into the following attributes: ${attributes}.
+        </p>
+      </section>
     `;
   }
 
@@ -588,6 +599,61 @@ export class AbilityPick extends HTMLElement {
     if (!this.hasAttribute('unlock-attributes')) return [];
 
     return this.getAttribute('unlock-attributes').split(/\s+/).filter(Boolean);
+  }
+
+  #hasUnlockRequirements() {
+    return (
+      this.#unlockLevel != null &&
+      this.#unlockAttributePoints != null &&
+      this.#unlockAttributes.length > 0
+    );
+  }
+
+  /**
+   * @param {number} currentLevel
+   */
+  updateUnlockRequirements(currentLevel) {
+    const unlockRequirementState = this.#getUnlockRequirementState(currentLevel);
+    if (!unlockRequirementState) return;
+
+    if (unlockRequirementState.isSatisfied) {
+      this.hideUnlockRequirements();
+      return;
+    }
+
+    this.showUnlockRequirements();
+    if (this.#unlockRequirementAttributePointsElement) {
+      this.#unlockRequirementAttributePointsElement.textContent =
+        unlockRequirementState.remainingAttributePoints;
+    }
+  }
+
+  showUnlockRequirements() {
+    if (!this.#unlockRequirementsSectionElement) return;
+
+    this.#unlockRequirementsSectionElement.hidden = false;
+  }
+
+  hideUnlockRequirements() {
+    if (!this.#unlockRequirementsSectionElement) return;
+
+    this.#unlockRequirementsSectionElement.hidden = true;
+  }
+
+  #getUnlockRequirementState(currentLevel) {
+    if (!this.#character || !this.#hasUnlockRequirements()) {
+      return null;
+    }
+
+    return computeAbilityUnlockRequirementState(
+      {
+        level: this.#unlockLevel,
+        attributePoints: this.#unlockAttributePoints,
+        attributes: this.#unlockAttributes,
+      },
+      this.#character,
+      currentLevel,
+    );
   }
 
   #getBaseTooltipValues() {

--- a/talent-calculator.js
+++ b/talent-calculator.js
@@ -624,9 +624,10 @@ class TalentCalculator extends HTMLElement {
 
   #updateAllFormulas() {
     const showFormulasCheckbox = this.querySelector('#show-formulas-checkbox');
-    this.querySelectorAll('ability-pick').forEach((abilityPick) =>
-      abilityPick.evalAllFormulas(showFormulasCheckbox.checked),
-    );
+    this.querySelectorAll('ability-pick').forEach((abilityPick) => {
+      abilityPick.evalAllFormulas(showFormulasCheckbox.checked);
+      abilityPick.updateUnlockRequirements(this.#ledger.level);
+    });
   }
 
   #updateShieldFormulas() {


### PR DESCRIPTION
## Summary

- Add a helper for computing ability unlock requirement state from current level and invested attribute points.
- Update unlock requirement tooltips to show the remaining combined attribute points needed.
- Hide unlock requirement text once the current level or combined attribute investment satisfies the requirement.

## Notes

This only updates tooltip display. Enforcing ability availability remains out of scope.

Closes #278 
