### PR TITLE
Remove unlock requirements from Embodiment of Resilience

### DIFF
--- a/index.html
+++ b/index.html
@@ -3223,6 +3223,7 @@
           img="img/abilities/ranged_weapons/Dexterity.png"
           label="Dexterity"
           key="thrift"
+          passive
           requires="Requires a ranged weapon and ammunition"
           tooltip-bottom-left
         >
@@ -3451,6 +3452,7 @@
           img="img/abilities/ranged_weapons/Anticipation.png"
           label="Anticipation"
           key="anticipation"
+          passive
           requires="Requires a ranged weapon and ammunition"
           tooltip-mid-left
           unlock-level="10"
@@ -3811,12 +3813,10 @@
           img="img/abilities/shields/Embodiment_of_Resilience.png"
           label="Embodiment of Resilience"
           key="ultimate_resilience"
+          passive
           modifiers="Willpower"
           requires="Requires a shield"
           tooltip-bottom-right
-          unlock-level="10"
-          unlock-attribute-points="8"
-          unlock-attributes="VIT STR"
         >
           <div slot="description" class="tooltip-description">
             <p>

--- a/tooltips/stoneshard-tooltips-and-formulas.json
+++ b/tooltips/stoneshard-tooltips-and-formulas.json
@@ -567,7 +567,7 @@
         "Damage_Debuff": "(5 + 0.5 * PRC)",
         "Move_Debuff": "(-((5 + 0.5 * AGL)))"
       },
-      "is_passive": true,
+      "is_passive": false,
       "attributes": {
         "target": "Target Object",
         "range": "1",
@@ -2840,15 +2840,7 @@
       "formulas": {
         "Regen_MP": "(-5 + WIL)"
       },
-      "is_passive": true,
-      "unlock_requirements": {
-        "level": 10,
-        "attribute_points": 8,
-        "attributes": [
-          "VIT",
-          "STR"
-        ]
-      }
+      "is_passive": true
     },
     {
       "key": "Breakthrough",

--- a/umt-exporter/ExtractStoneshardTooltipsAndFormulas.csx
+++ b/umt-exporter/ExtractStoneshardTooltipsAndFormulas.csx
@@ -361,7 +361,7 @@ await Task.Run(() => {
             foreach (UndertaleCode code in Data.Code)
             {
                 var codeName = code.Name.Content.ToLower();
-                if (codeName.StartsWith("gml_object_o_pass_skill_" + lowerSkillKey))
+                if (IsPassiveSkillCodeName(codeName, lowerSkillKey))
                 {
                     skill.IsPassive = true;
                 }
@@ -387,6 +387,9 @@ await Task.Run(() => {
                 }
                 if (IsUnlockRequirementsCodeName(codeName, lowerSkillKey))
                 {
+                    if (ShouldSkipUnlockRequirements(treeName, lowerSkillKey))
+                        continue;
+
                     var unlockCode = code != null ? Decompiler.Decompile(code, DECOMPILE_CONTEXT.Value) : "";
                     var unlockRequirements = ExtractUnlockRequirementsFromCode(unlockCode);
                     if (unlockRequirements != null)
@@ -452,6 +455,17 @@ public static bool IsUnlockRequirementsCodeName(string codeName, string lowerSki
 {
     return codeName == "gml_object_o_skill_" + lowerSkillKey + "_ico_create_0"
         || codeName == "gml_object_o_pass_skill_" + lowerSkillKey + "_create_0";
+}
+
+public static bool IsPassiveSkillCodeName(string codeName, string lowerSkillKey)
+{
+    return codeName == "gml_object_o_pass_skill_" + lowerSkillKey + "_create_0";
+}
+
+public static bool ShouldSkipUnlockRequirements(string treeName, string lowerSkillKey)
+{
+    // This tier 1 passive contains unlock variables in game code, but should be open with the tree.
+    return treeName == "shields" && lowerSkillKey == "ultimate_resilience";
 }
 
 public static SkillUnlockRequirements ExtractUnlockRequirementsFromCode(string code)


### PR DESCRIPTION
## Summary

- Skip extracted unlock requirements for Embodiment of Resilience, since it is a tier-1 Shields passive.
- Tighten passive skill detection in the extractor to avoid prefix collisions such as `Armor_Break` matching `armor_breaker`.
- Update generated tooltip data and ability metadata for the affected abilities.

## Notes

This keeps the fix scoped to extractor/data corrections. Unrelated tooltip and formula changes from the latest game export are left out.

Closes #282 